### PR TITLE
Removes headers ID; corrects code blocks

### DIFF
--- a/docs/expression/aggregate.md
+++ b/docs/expression/aggregate.md
@@ -9,7 +9,7 @@ title: Aggregate expressions
 
 ---
 
-## `!AVG`: Average {#EXPR-AVG}
+## `!AVG`: Average 
 
 Type: _Sequence_
 
@@ -19,18 +19,18 @@ Calculate the average / arithmetic mean.
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !AVG
 - 1
 - 2
 - 3
-{% endhighlight %}
+```
 
 Calculation of the average `(1+2+3)/3`,  the result is `2`.
 
 ---
 
-## `!MAX`: Maximum {#EXPR-MAX}
+## `!MAX`: Maximum 
 
 Type: _Sequence_
 
@@ -39,19 +39,19 @@ Returns a maximum value from the seqence.
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !MAX
 - 1.5
 - 2.6
 - 3.05
 - 4.45
 - 5.1
-{% endhighlight %}
+```
 
 
 ---
 
-## `!MIN`: Minimum {#EXPR-MIN}
+## `!MIN`: Minimum 
 
 Type: _Sequence_
 
@@ -59,24 +59,24 @@ Returns a minimum value from the seqence.
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !MIN
 - 0.5
 - 2.6
 - 3.05
 - 4.45
 - 5.1
-{% endhighlight %}
+```
 
 ---
 
-## `!COUNT`: Count number of elements {#EXPR-COUNT}
+## `!COUNT`: Count number of elements 
 
 Type: _Sequence_
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !COUNT
 - Frodo Baggins
 - Sam Gamgee
@@ -87,13 +87,13 @@ Type: _Sequence_
 - Boromir of Gondor
 - Merry Brandybuck
 - Pippin Took
-{% endhighlight %}
+```
 
 Returns `9`.
 
 ---
 
-## `!MEDIAN`: The middle value {#EXPR-MEDIAN}
+## `!MEDIAN`: The middle value 
 
 Type: _Sequence_
 
@@ -102,18 +102,18 @@ Type: _Sequence_
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !MEDIAN
 - 1
 - 4
 - -1
 - 9
 - 101
-{% endhighlight %}
+```
 
 ---
 
-## `!MODE`: Value that appears most often {#EXPR-MODE}
+## `!MODE`: Value that appears most often 
 
 Type: _Sequence_
 
@@ -122,7 +122,7 @@ Type: _Sequence_
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !MODE
 - -10
 - -10
@@ -133,11 +133,11 @@ Type: _Sequence_
 - 3
 - 4
 - 5
-{% endhighlight %}
+```
 
 ---
 
-## `!RANGE`: The difference between the largest and smallest value {#EXPR-RANGE}
+## `!RANGE`: The difference between the largest and smallest value 
 
 Type: _Sequence_
 
@@ -147,11 +147,11 @@ Calculates the difference between the largest and smallest values.
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !RANGE
 - 1
 - 3
 - 4
 - 20
 - -1
-{% endhighlight %}
+```

--- a/docs/expression/arithmetics.md
+++ b/docs/expression/arithmetics.md
@@ -9,7 +9,7 @@ title: Arithmetics expressions
 
 ---
 
-## `!ADD`: Addition {#EXPR-ADD}
+## `!ADD`: Addition 
 
 Type: _Sequence_
 
@@ -26,59 +26,59 @@ You can add following types:
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !ADD
 - 4
 - -5
 - 6
-{% endhighlight %}
+```
 
 Calculates `4+(-5)+6`, so the result is `5`.
 
 ---
 
-## `!SUB`: Substraction {#EXPR-SUB}
+## `!SUB`: Substraction 
 
 Type: _Sequence_
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !SUB
 - 3
 - 1
 - -5
-{% endhighlight %}
+```
 
 ---
 
 
-## `!MUL`: Multiplication {#EXPR-MUL}
+## `!MUL`: Multiplication 
 
 Type: _Sequence_
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !MUL
 - 1.5
 - 5.5
 - 3.2
-{% endhighlight %}
+```
 
 ---
 
-## `!DIV`: Division {#EXPR-DIV}
+## `!DIV`: Division 
 
 Type: _Sequence_
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !DIV
 - 21
 - 1.5
-{% endhighlight %}
+```
 
 
 ### Division by zero
@@ -89,18 +89,18 @@ Division by zero produces the error, which can cascade thru the expression.
 The first item in `!TRY` is a `!DIV` that can produce division by zero error.
 The second item is a value that will be returned when such an error occurs.
 
-{% highlight yaml %}
+```yaml
 !TRY
 - !DIV
   - !ARG input
   - 0.0
 - 5.0
-{% endhighlight %}
+```
 
 
 ---
 
-## `!MOD`: Reminder {#EXPR-MOD}
+## `!MOD`: Reminder 
 
 Type: _Sequence_
 
@@ -110,15 +110,15 @@ Calculate the signed remainder of a division (aka modulo operation).
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !MOD
 - 21
 - 1.5
-{% endhighlight %}
+```
 
 ---
 
-## `!POW`: Exponentiation {#EXPR-POW}
+## `!POW`: Exponentiation 
 
 Type: _Sequence_
 
@@ -128,8 +128,8 @@ Calculate the exponent or power.
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !POW
 - 2
 - 8
-{% endhighlight %}
+```

--- a/docs/expression/bitwise.md
+++ b/docs/expression/bitwise.md
@@ -17,97 +17,97 @@ There are also bitwise `!AND`, `!OR` and `!NOT` expression, for details, continu
 
 --- 
 
-## `!SAL`: Left arithmetic shift {#EXPR-SAL}
+## `!SAL`: Left arithmetic shift 
 
 Type: _Mapping_.
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !SAL
 what: <...>
 by: <...>
-{% endhighlight %}
+```
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !SAL
 what: 60
 by: 2
-{% endhighlight %}
+```
 
 
 ---
 
-## `!SAR`: Right arithmetic shift {#EXPR-SAR}
+## `!SAR`: Right arithmetic shift 
 
 Type: _Mapping_.
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !SAR
 what: <...>
 by: <...>
-{% endhighlight %}
+```
 
 
 ---
 
-## `!SHL`: Left logical shift {#EXPR-SHL}
+## `!SHL`: Left logical shift 
 
 Type: _Mapping_.
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !SHL
 what: <...>
 by: <...>
-{% endhighlight %}
+```
 
 
 ---
 
-## `!SHR`: Right logical shift  {#EXPR-SHR}
+## `!SHR`: Right logical shift  
 
 Type: _Mapping_.
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !SHR
 what: <...>
 by: <...>
-{% endhighlight %}
+```
 
 
 ---
 
-## `!ROL`: Left rotation (circular) shift {#EXPR-ROL}
+## `!ROL`: Left rotation (circular) shift 
 
 Type: _Mapping_.
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !ROL
 what: <...>
 by: <...>
-{% endhighlight %}
+```
 
 
 ---
 
-## `!ROR`: Right rotation (circular) shift {#EXPR-ROR}
+## `!ROR`: Right rotation (circular) shift 
 
 Type: _Mapping_.
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !ROR
 what: <...>
 by: <...>
-{% endhighlight %}
+```

--- a/docs/expression/comparisons.md
+++ b/docs/expression/comparisons.md
@@ -11,7 +11,7 @@ Test expression evaluates inputs and returns boolean value `true` or `false` bas
 
 ---
 
-## `!EQ`: Equal {#EXPR-EQ}
+## `!EQ`: Equal 
 
 Type: _Sequence_.
 
@@ -29,7 +29,7 @@ This compares `count` argument with `3`.
 
 ---
 
-## `!NE`: Not equal {#EXPR-NE}
+## `!NE`: Not equal 
 
 Type: _Sequence_.
 
@@ -38,94 +38,94 @@ This is negative counterpart to `!EQ`.
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !NE
 - !ARG name
 - Frodo
-{% endhighlight %}
+```
 
 
 ---
 
-## `!LT`: Less than {#EXPR-LT}
+## `!LT`: Less than 
 
 Type: _Sequence_.
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !LT
 - !ARG count
 - 5
-{% endhighlight %}
+```
 
 Example of a `count < 5` test.
 
 
 ---
 
-## `!LE`: Less than and equal {#EXPR-LE}
+## `!LE`: Less than and equal 
 
 Type: _Sequence_.
 
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !LE
 - 2
 - !ARG count
 - 5
-{% endhighlight %}
+```
 
 Example of a range `2 <= count <= 5` test.
 
 
 ---
 
-## `!GT`: Greater than {#EXPR-GT}
+## `!GT`: Greater than 
 
 Type: _Sequence_.
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !GT [!ARG count, 5]
-{% endhighlight %}
+```
 
 Example of a `count > 5` test using a compacted YAML form.
 
 
 ---
 
-## `!GE`: Greater than  and equal {#EXPR-GE}
+## `!GE`: Greater than  and equal 
 
 Type: _Sequence_.
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !GT
 - !ARG count
 - 5
-{% endhighlight %}
+```
 
 Example of a `count >= 5` test.
 
 
 ---
 
-## `!IN`: Membership test {#EXPR-IN}
+## `!IN`: Membership test 
 
 Type: _Mapping_.
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !IN
 what: <...>
 where: <...>
-{% endhighlight %}
+```
 
 The `!IN` expression is used to check if a value `what` exists in a value `where` or not.
 Value `where` is a string, container (list, set, dictionary), structural type etc.
@@ -133,7 +133,7 @@ Evaluate to "true" if it finds a value `what` in the specified value `where` and
 
 ### Examples
 
-{% highlight yaml %}
+```yaml
 !IN
 what: 5
 where:
@@ -142,15 +142,15 @@ where:
   - 3
   - 4
   - 5
-{% endhighlight %}
+```
 
 Check for a presence of the value `5` in the list `where`. Returns "true".
 
 
-{% highlight yaml %}
+```yaml
 !IN
 what: "Willy"
 where: "John Willy Boo"
-{% endhighlight %}
+```
 
 Check for a presence of the substring "Willy" in the `where` value. Returns "true".

--- a/docs/expression/control.md
+++ b/docs/expression/control.md
@@ -11,7 +11,7 @@ SP-Lang provides a variety of control flow statements.
 
 --- 
 
-## `!IF`: Simple conditional branching  {#EXPR-IF}
+## `!IF`: Simple conditional branching  
 
 Type: _Mapping_.
 
@@ -20,12 +20,12 @@ The `!IF` expression is a decision-making expression that guides the evaluation 
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !IF
 test: <expression>
 then: <expression>
 else: <expression>
-{% endhighlight %}
+```
 
 
 `test` should provide boolean value, based on this value `then` (for `true`) or `else` (for `false`) branch is evaluated.
@@ -35,7 +35,7 @@ else: <expression>
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !IF
 test:
   !EQ
@@ -45,11 +45,11 @@ then:
   It is two.
 else:
   It is NOT two.
-{% endhighlight %}
+```
 
 ---
 
-## `!WHEN`: Powerful branching  {#EXPR-WHEN}
+## `!WHEN`: Powerful branching  
 
 Type: _Sequence_.
 
@@ -59,7 +59,7 @@ Cases can match many different patterns, including interval matches, tuples, and
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !WHEN
 - test: <expression>
   then: <expression>
@@ -73,7 +73,7 @@ Cases can match many different patterns, including interval matches, tuples, and
 - ...
 
 - else: <expression>
-{% endhighlight %}
+```
 
 
 If `else` is not provided, then `WHEN` returns `False`.
@@ -83,7 +83,7 @@ If `else` is not provided, then `WHEN` returns `False`.
 
 Example of `!WHEN` use for exact match, range match and set match:
 
-{% highlight yaml %}
+```yaml
 !WHEN
 
 # Exact value match
@@ -117,18 +117,18 @@ Example of `!WHEN` use for exact match, range match and set match:
 
 - else:
     "Unknown"
-{% endhighlight %}
+```
 
 --- 
 
-## `!MATCH`: Pattern matching {#EXPR-MATCH}
+## `!MATCH`: Pattern matching 
 
 Type: _Mapping_.
 
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !MATCH
 what: <what-expression>
 with:
@@ -137,7 +137,7 @@ with:
   ...
 else:
   <expression>
-{% endhighlight %}
+```
 
 `!MATCH` expression evaluates the `what-expression`, matching the expression's value to a case clause, and executes `expression` associated with that case.
 
@@ -149,7 +149,7 @@ The expression fails with error when no matching `<value>` is found and `else` b
 
 Example of `!MATCH`:
 
-{% highlight yaml %}
+```yaml
 !MATCH
 what: 1
 with:
@@ -158,12 +158,12 @@ with:
   3: "Three"
 else:
   "Other number"
-{% endhighlight %}
+```
 
     
 Use of `!MATCH` to structure the code:
 
-{% highlight yaml %}
+```yaml
 !MATCH
 what: !ARG code
 with:
@@ -171,25 +171,25 @@ with:
   2: !INCLUDE code-2.yaml
 else:
   !INCLUDE code-else.yaml
-{% endhighlight %}
+```
   
 ---
 
-## `!TRY`: Execute till first non-error expression  {#EXPR-TRY}
+## `!TRY`: Execute till first non-error expression  
 
 
 Type: _Sequence_
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 
 !TRY
 - <expression>
 - <expression>
 - <expression>
 ...
-{% endhighlight %}
+```
 
 Iterate thru expression (top down), if the expression return non-null (`None`) result, stop iteration and return that value.
 Otherwise continue to the next expression.
@@ -202,7 +202,7 @@ It was obsoleted in November 2022.
     
 ---
 
-## `!MAP`: Apply the expression on each element in a sequence {#EXPR-MAP}
+## `!MAP`: Apply the expression on each element in a sequence 
 
 Type: _Mapping_.
 
@@ -230,7 +230,7 @@ Result is `[11, 12, 13, 14, 15, 16, 17]`.
 
 ---
 
-## `!REDUCE`: Reduce the elements of an list into a single value {#EXPR-REDUCE}
+## `!REDUCE`: Reduce the elements of an list into a single value 
 
 Type: _Mapping_.
     

--- a/docs/expression/datetime.md
+++ b/docs/expression/datetime.md
@@ -13,7 +13,7 @@ It is in the UTC timezone.
 
 ---
 
-## `!NOW`: A current date and time {#EXPR-NOW}
+## `!NOW`: A current date and time 
 
 Type: _Mapping_.
 
@@ -27,7 +27,7 @@ Get a current date and time.
 
 ---
 
-## `!DATETIME`: Construct the date/time {#EXPR-DATETIME}
+## `!DATETIME`: Construct the date/time 
 
 Type: _Mapping_.
 
@@ -101,7 +101,7 @@ timezone: "+05:00"
 
 ---
 
-## `!DATETIME.FORMAT`: Format a date/time {#EXPR-DATETIME-FORMAT}
+## `!DATETIME.FORMAT`: Format a date/time 
 
 Type: _Mapping_.
 
@@ -166,7 +166,7 @@ Prints the current local time as eg. `2022-12-31 12:34:56` using the timezone "E
 
 ---
 
-## `!DATETIME.PARSE`: Parse a date/time {#EXPR-DATETIME-PARSE}
+## `!DATETIME.PARSE`: Parse a date/time 
 
 Type: _Mapping_.
 
@@ -198,7 +198,7 @@ format: "%y-%m-%dT%H:%M:%S%z"
 
 ---
 
-## `!GET`: Get a date/time component {#EXPR-DATETIME-GET}
+## `!GET`: Get a date/time component 
 
 Type: _Mapping_.
 

--- a/docs/expression/dict.md
+++ b/docs/expression/dict.md
@@ -18,7 +18,7 @@ Hint: You may know this structure under alernative names "associative array" or 
 
 --- 
 
-## `!DICT`: Dictionary {#EXPR-DICT}
+## `!DICT`: Dictionary 
 
 Type:  _Mapping_
 
@@ -92,7 +92,7 @@ In the above example, the type of the dictionary is `{str:any}`, the type of key
 
 --- 
 
-## `!GET`: Get the value from a dictionary {#EXPR-DICT-GET}
+## `!GET`: Get the value from a dictionary 
 
 Type: _Mapping_.
 
@@ -128,7 +128,7 @@ Returns `Three`.
 
 --- 
 
-## `!IN`: Membership test {#EXPR-DICT-IN}
+## `!IN`: Membership test 
 
 Type: _Mapping_.
 

--- a/docs/expression/directives.md
+++ b/docs/expression/directives.md
@@ -11,7 +11,7 @@ NOTE: SP-Lang directives are expanded during compilation. They are not expressio
 
 --- 
 
-## `!INCLUDE`: Insert the content of another file {#EXPR-INCLUDE}
+## `!INCLUDE`: Insert the content of another file 
 
 Type: Scalar, Directive.
 
@@ -21,9 +21,9 @@ If included file is not found, SP-Lang renders error.
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !INCLUDE <filename>
-{% endhighlight %}
+```
 
 The `filename` is a name of the file in the library to be included.
 
@@ -36,19 +36,19 @@ It could be:
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !INCLUDE other_file.yaml
-{% endhighlight %}
+```
 
 This is a simple inclusion of the `other_file.yaml`.
   
 
-{% highlight yaml %}
+```yaml
 !MATCH
 what: !GET {...}
 with:
   'group1': !INCLUDE inc_group1
   'group2': !INCLUDE inc_group2
-{% endhighlight %}
+```
 
 In this example, `!INCLUDE` is used to decompose a larger expression into a logically separated files.

--- a/docs/expression/function.md
+++ b/docs/expression/function.md
@@ -10,7 +10,7 @@ title: Functions expressions
 
 --- 
 
-## `!ARGUMENT`, `!ARG`: Get a function argument  {#EXPR-ARG}
+## `!ARGUMENT`, `!ARG`: Get a function argument  
 
 Type: _Mapping_.
 
@@ -31,7 +31,7 @@ Provides an access to an argument `name`.
 
 --- 
 
-## `!FUNCTION`, `!FN`: Define a function {#EXPR-FUNCTION}
+## `!FUNCTION`, `!FN`: Define a function 
 
 
 Type: _Mapping_.
@@ -85,7 +85,7 @@ do:
 
 --- 
 
-## `!SELF`: Apply a current function  {#EXPR-SET}
+## `!SELF`: Apply a current function  
 
 Type: _Mapping_.
 

--- a/docs/expression/ip.md
+++ b/docs/expression/ip.md
@@ -13,7 +13,7 @@ IPv4 are mapped into IPv6 space, using [RFC 4291 "IPv4-Mapped IPv6 Address"](htt
 
 --- 
 
-## `!IP.FORMAT`: Convert an IP address into a string  {#EXPR-IP-FORMAT}
+## `!IP.FORMAT`: Convert an IP address into a string  
 
 Type: _Mapping_.
 
@@ -29,7 +29,7 @@ Convert the internal representation of the IP address into a string.
 
 --- 
 
-## `!IP.INSUBNET`: Check if IP address falls into a subnet {#EXPR-IP-INSUBNET}
+## `!IP.INSUBNET`: Check if IP address falls into a subnet 
 
 Type: _Mapping_.
 

--- a/docs/expression/json.md
+++ b/docs/expression/json.md
@@ -11,7 +11,7 @@ SP-Lang offers a [high-speed access](https://simdjson.org) to JSON data objects.
 
 --- 
 
-## `!GET`: Get the value from a JSON {#EXPR-JSON-GET}
+## `!GET`: Get the value from a JSON 
 
 Type: _Mapping_.
 
@@ -78,7 +78,7 @@ from: !ARG jsonmessage
 
 --- 
 
-## `!JSON.PARSE`: Parse JSON {#EXPR-JSON-PARSE}
+## `!JSON.PARSE`: Parse JSON 
 
 Type: _Mapping_.
 

--- a/docs/expression/list.md
+++ b/docs/expression/list.md
@@ -17,17 +17,17 @@ _Note: The list is sometimes also called an array (inaccurately)._
 
 --- 
 
-## `!LIST`: List of items {#EXPR-LIST}
+## `!LIST`: List of items 
 
 Type:  _Implicit sequence_, _Mapping_.
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !LIST
 - ...
 - ...
-{% endhighlight %}
+```
 
 _Hint: Use `!COUNT` to determine number of items in the list._
 
@@ -36,37 +36,37 @@ _Hint: Use `!COUNT` to determine number of items in the list._
 
 There are several ways, how a list can be specified in SP-Lang:
 
-{% highlight yaml %}
+```yaml
 !LIST
 - "One"
 - "Two"
 - "Three"
 - "Four"
 - "Five"
-{% endhighlight %}
+```
 
 
 Implicit list using [YAML block sequences](https://yaml.org/spec/1.2.2/#821-block-sequences):
 
-{% highlight yaml %}
+```yaml
 - "One"
 - "Two"
 - "Three"
 - "Four"
 - "Five"
-{% endhighlight %}
+```
 
 
 Implicit list using [YAML flow sequences](https://yaml.org/spec/1.2.2/#741-flow-sequences):
 
-{% highlight yaml %}
+```yaml
 ["One", "Two", "Three", "Four", "Five"]
-{% endhighlight %}
+```
 
 
 The mapping form:
 
-{% highlight yaml %}
+```yaml
 !LIST
 with:
   - "One"
@@ -74,22 +74,22 @@ with:
   - "Three"
   - "Four"
   - "Five"
-{% endhighlight %}
+```
 
 --- 
 
-## `!GET`: Get the item from the list {#EXPR-LIST-GET}
+## `!GET`: Get the item from the list 
 
 Type: _Mapping_.
 
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !GET
 what: <index of the item in the list>
 from: <list>
-{% endhighlight %}
+```
 
 `index` is an integer (number).
 
@@ -101,7 +101,7 @@ If the `index` is out of bound of the list, the statement returns with error.
 
 ### Examples
 
-{% highlight yaml %}
+```yaml
 !GET
 what: 3
 from:
@@ -112,12 +112,12 @@ from:
   - 50
   - 80
   - 120
-{% endhighlight %}
+```
 
 Returns `50`.
 
 
-{% highlight yaml %}
+```yaml
 !GET
 what: -1
 from:
@@ -128,7 +128,7 @@ from:
   - 50
   - 80
   - 120
-{% endhighlight %}
+```
 
 Returns the last item in the list, which is `120`.
 

--- a/docs/expression/logic.md
+++ b/docs/expression/logic.md
@@ -9,18 +9,18 @@ title: Logic expressions
 
 ---
 
-## `!AND`: Conjunction {#EXPR-AND}
+## `!AND`: Conjunction 
 
 Type: _Sequence_
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !AND
 - <expression 1>
 - <expression 2>
 - ...
-{% endhighlight %}
+```
 
 ### Boolean `!AND`
 
@@ -28,7 +28,7 @@ Boolean conjunction `!AND` is an boolean functional operation on sequence of log
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !AND
 - !EQ
   - !ARG vendor
@@ -36,7 +36,7 @@ Boolean conjunction `!AND` is an boolean functional operation on sequence of log
 - !EQ 
   - !ARG product
   - LogMan.io
-{% endhighlight %}
+```
 
 
 ### Bitwise  `!AND`
@@ -45,28 +45,28 @@ When `!AND` is applied on integers (instead on boolean) types, it provides a bit
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !AND
 - !ARG PRI
 - 7
-{% endhighlight %}
+```
 
 In this example, the argument `PRI` is masked with 7 (in binary `00000111`).
 
 ---
 
-## `!OR`: Disjunction {#EXPR-OR}
+## `!OR`: Disjunction 
 
 Type: _Sequence_
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !OR
 - <expression 1>
 - <expression 2>
 - ...
-{% endhighlight %}
+```
 
 
 ### Boolean `!OR`
@@ -80,16 +80,16 @@ When `!OR` is applied on integers (instead on boolean) types, it provides a bitw
 
 ---
 
-## `!NOT`: Negation {#EXPR-NOT}
+## `!NOT`: Negation 
 
 Type: _Mapping_.
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !NOT
 what: <expression>
-{% endhighlight %}
+```
 
 ### Boolean `!NOT`
 

--- a/docs/expression/lookup.md
+++ b/docs/expression/lookup.md
@@ -9,7 +9,7 @@ title: Lookup expressions
 
 ---
 
-## `!LOOKUP`: xxx {#EXPR-LOOKUP}
+## `!LOOKUP`: xxx 
 
 Type: _Mapping_.
 

--- a/docs/expression/record.md
+++ b/docs/expression/record.md
@@ -16,19 +16,19 @@ _Note: The record is built on top of `!TUPLE`._
 
 --- 
 
-## `!RECORD`: A collection of named items {#EXPR-RECORD}
+## `!RECORD`: A collection of named items 
 
 Type:  _Mapping_.
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !RECORD
 with:
   item1: <item 1>
   item2: <item 2>
   ...
-{% endhighlight %}
+```
 
 `item1` and `item2` are labels of respective items in the record.
 
@@ -37,55 +37,55 @@ The order of the items is preserved.
 
 ### Examples
 
-{% highlight yaml %}
+```yaml
 !RECORD
 with:
   name: John Doe
   age: 37
   height: 175.4
-{% endhighlight %}
+```
 
 
 Use of the YAML flow form:
 
-{% highlight yaml %}
+```yaml
 !RECORD {with: {name: John Doe, age: 37, height: 175.4} }
-{% endhighlight %}
+```
 
 
 Use of the `!!record` tag:
 
-{% highlight yaml %}
+```yaml
 !!record {name: John Doe, age: 37, height: 175.4}
-{% endhighlight %}
+```
 
 
 Enforce specific type of the item:
 
-{% highlight yaml %}
+```yaml
 !RECORD
 with:
   name: John Doe
   age: !!ui8 37
   height: 175.4
-{% endhighlight %}
+```
 
 Field `age` will have a type `ui8`.
 
 
 --- 
 
-## `!GET`: Get the item from a record {#EXPR-RECORD-GET}
+## `!GET`: Get the item from a record 
 
 Type: _Mapping_.
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !GET
 what: <name or index of the item>
 from: <record>
-{% endhighlight %}
+```
 
 If `what` is a string, then it is a name of the field in the record.
 
@@ -99,7 +99,7 @@ If the `what` is out of bound of the list, the statement returns with error.
 
 Using names of items:
 
-{% highlight yaml %}
+```yaml
 !GET
 what: name
 from:
@@ -108,14 +108,14 @@ from:
     name: John Doe
     age: 32
     height: 127.5
-{% endhighlight %}
+```
 
 Returns `John Doe`.
 
 
 Using the _index_ of items:
 
-{% highlight yaml %}
+```yaml
 !GET
 what: 1
 from:
@@ -124,14 +124,14 @@ from:
     name: John Doe
     age: 32
     height: 127.5
-{% endhighlight %}
+```
 
 Returns `32`, a value of `age` item.
 
 
 Using the _negative index_ of items:
 
-{% highlight yaml %}
+```yaml
 !GET
 what: -1
 from:
@@ -140,6 +140,6 @@ from:
     name: John Doe
     age: 32
     height: 127.5
-{% endhighlight %}
+```
 
 Returns `127.5`, a value of `height` item.

--- a/docs/expression/regex.md
+++ b/docs/expression/regex.md
@@ -11,19 +11,19 @@ _Hint: Use [Regexr](https://regexr.com) to develop and test regular expressions.
 
 --- 
 
-## `!REGEX`: Regular expression search  {#EXPR-REGEX}
+## `!REGEX`: Regular expression search  
 
 Type: _Mapping_.
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !REGEX
 what: <string>
 regex: <regex>
 hit: <hit>
 miss: <miss>
-{% endhighlight %}
+```
 
 Scan through `what` string looking for any location where regular expression `regex` produces a match.
 If there is a match, then returns `hit`, otherwise `miss` is returned.
@@ -35,7 +35,7 @@ The expression `miss` is optional, default value is `false`.
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !IF
 test:
   !REGEX
@@ -45,61 +45,61 @@ then:
   "Yes :-)"
 else:
   "No ;-("
-{% endhighlight %}
+```
 
 The above example can be also written as:
   
-{% highlight yaml %}
+```yaml
 !REGEX
 what: "Hello world!"
 regex: "world"
 hit: "Yes :-)"
 miss: "No ;-("
-{% endhighlight %}
+```
 
 --- 
 
-## `!REGEX.REPLACE`: Regular expression replace  {#EXPR-REGEX-REPLACE}
+## `!REGEX.REPLACE`: Regular expression replace  
 
 Type: _Mapping_.
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !REGEX.REPLACE
 what: <string>
 regex: <regex>
 by: <string>
-{% endhighlight %}
+```
 
 Replace regular expression `regex` matches in `what` by value of `by`.
 
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !REGEX.REPLACE
 what: "Hello world!"
 regex: "world"
 by: "Mars"
-{% endhighlight %}
+```
 
 Returns: `Hello Mars!`
 
 --- 
 
-## `!REGEX.SPLIT`: Split a string by a regular expression  {#EXPR-REGEX-SPLIT}
+## `!REGEX.SPLIT`: Split a string by a regular expression  
 
 Type: _Mapping_.
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !REGEX.SPLIT
 what: <string>
 regex: <regex>
 max: <integer>
-{% endhighlight %}
+```
 
 Split string `what` by regular expression `regex`.
 
@@ -108,43 +108,43 @@ An optional argument `max` specify the maximum number of splits.
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !REGEX.SPLIT
 what: "07/14/2007 12:34:56"
 regex: "[/ :]"
-{% endhighlight %}
+```
 
 Returns: `['07', '14', '2007', '12', '34', '56']`
 
 --- 
 
-## `!REGEX.FINDALL`: Find all occurences by a regular expression  {#EXPR-REGEX-FINDALL}
+## `!REGEX.FINDALL`: Find all occurences by a regular expression  
 
 Type: _Mapping_.
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !REGEX.FINDALL
 what: <string>
 regex: <regex>
-{% endhighlight %}
+```
 
 Find all matches of `regex` in the string `what`.
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !REGEX.FINDALL
 what: "Frodo, Sam, Gandalf, Legolas, Gimli, Aragorn, Boromir, Merry, Pippin"
 regex: \w+
-{% endhighlight %}
+```
 
 Returns: `['Frodo', 'Sam', 'Gandalf', 'Legolas', 'Gimli', 'Aragorn', 'Boromir', 'Merry', 'Pippin']`
 
 ---
 
-## `!REGEX.PARSE`: Parse by a regular expression {#EXPR-REGEX-PARSE}
+## `!REGEX.PARSE`: Parse by a regular expression 
 
 Type: _Mapping_.
 

--- a/docs/expression/set.md
+++ b/docs/expression/set.md
@@ -16,7 +16,7 @@ A set is best suited for a testing value for membership rather than retrieving a
 
 --- 
 
-## `!SET`: Set of items {#EXPR-SET}
+## `!SET`: Set of items 
 
 Type:  _Implicit sequence_, _Mapping_.
 
@@ -77,7 +77,7 @@ with:
 
 --- 
 
-## `!IN`: Membership test {#EXPR-SET-IN}
+## `!IN`: Membership test 
 
 Type: _Mapping_.
 

--- a/docs/expression/string.md
+++ b/docs/expression/string.md
@@ -9,28 +9,28 @@ title: String expressions
 
 ---
 
-## `!IN`: Test if the string contains a substring {#EXPR-IN}
+## `!IN`: Test if the string contains a substring 
 
 Type: _Mapping_.
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !IN
 what: <...>
 where: <...>
-{% endhighlight %}
+```
 
 The `!IN` expression is used to check if a string `what` exists in a string `where` or not.
 Evaluate to "true" if it finds a substring `what` in the string `where` and false otherwise.
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !IN
 what: "Willy"
 where: "John Willy Boo"
-{% endhighlight %}
+```
 
 Check for a presence of the substring "Willy" in the `where` value. Returns "true".
 
@@ -39,14 +39,14 @@ Check for a presence of the substring "Willy" in the `where` value. Returns "tru
 
 There is a special variant on `!IN` operator for checking if any of strings provided in `what` value (a list in this case) is in the string. It is efficient, optimized implementation of the multi-string matcher.
 
-{% highlight yaml %}
+```yaml
 !IN
 what:
   - "John"
   - "Boo"
   - "ly"
 where: "John Willy Boo"
-{% endhighlight %}
+```
 
 This is very efficient way of checking if at least one substring is present in the `where` string.
 It provides [Incremental String Matching](http://se.ethz.ch/~meyer/publications/string/string_matching.pdf) algorithm for fast pattern matching in strings.
@@ -54,7 +54,7 @@ It makes it an ideal tool for complex filtering as a standalone bit or an optimi
 
 Example of `!REGEX` optimization by multi-string `!IN`:
 
-{% highlight yaml %}
+```yaml
 !AND
 - !IN
   where: !ARG message
@@ -69,7 +69,7 @@ Example of `!REGEX` optimization by multi-string `!IN`:
 - !REGEX
   what: !ARG message
   regex: '(msgbox|showmod(?:al|eless)dialog|showhelp|prompt|write)|(test[0-9])|([a-z]@mail\.com)'
-{% endhighlight %}
+```
 
 This approach is recommended from applications in streams, where you need to filter an extensive amount of the data with assumption that only a smaller portion of the data matches the patters.
 An application of the `!REGEX` expression directly will slow processing down significantly, because it is complex regular expression.
@@ -85,7 +85,7 @@ For that reason, the `!IN` must be a perfect superset of the `!REGEX`, it means:
 
 ---
 
-## `!STARTSWITH`: Test if the string starts with a prefix {#EXPR-STARTSWITH}
+## `!STARTSWITH`: Test if the string starts with a prefix 
 
 Type: _Mapping_
 
@@ -93,24 +93,24 @@ Returns `true` if `what` string begins with `prefix`.
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !STARTSWITH
 what: <...>
 prefix: <...>
-{% endhighlight %}
+```
 
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !STARTSWITH
 what: "FooBar"
 prefix: "Foo"
-{% endhighlight %}
+```
 
 ---
 
-## `!ENDSWITH`: Test if the string ends with a postfix {#EXPR-ENDSWITH}
+## `!ENDSWITH`: Test if the string ends with a postfix 
 
 Type: _Mapping_
 
@@ -118,24 +118,24 @@ Returns `true` if `what` string ends with `postfix`.
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !ENDSWITH
 what: <...>
 postfix: <...>
-{% endhighlight %}
+```
 
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !ENDSWITH
 what: "autoexec.bat"
 postfix: ".bat"
-{% endhighlight %}
+```
 
 ---
 
-## `!SUBSTRING`: Extract part of the string {#EXPR-SUBSTRING}
+## `!SUBSTRING`: Extract part of the string 
 
 Type: _Mapping_
 
@@ -143,76 +143,76 @@ Return part of the string `what`, in between `from` and `to` index.
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !SUBSTRING
 what: <...>
 from: <...>
 to: <...>
-{% endhighlight %}
+```
 
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !SUBSTRING
 what: "FooBar"
 from: 1
 to: 3
-{% endhighlight %}
+```
 
 Returns `oo`.
 
 ---
 
-## `!LOWER`: Transform string to lower-case {#EXPR-LOWER}
+## `!LOWER`: Transform string to lower-case 
 
 Type: _Mapping_
 
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !LOWER
 what: <...>
-{% endhighlight %}
+```
 
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !LOWER
 what: "FooBar"
-{% endhighlight %}
+```
 
 Returns `foobar`.
 
 
 ---
 
-## `!UPPER`: Transform string to upper-case {#EXPR-UPPER}
+## `!UPPER`: Transform string to upper-case 
 
 Type: _Mapping_
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !UPPER
 what: <...>
-{% endhighlight %}
+```
 
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !UPPER
 what: "FooBar"
-{% endhighlight %}
+```
 
 Returns `FOOBAR`.
 
 ---
 
-## `!CUT`: Cut portion of the string {#EXPR-CUT}
+## `!CUT`: Cut portion of the string 
 
 Type: _Mapping_
 
@@ -220,12 +220,12 @@ Cut the string by a delimiter and return the piece identified by `field` index (
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !CUT
 what: <string>
 delimiter: <string>
 field: <int>
-{% endhighlight %}
+```
 
 The argument `value` string will be split using a `delimiter` argument.
 The argument `field` specifies a number of the splited strings to return, starting with 0.  
@@ -234,29 +234,29 @@ If the negative `field` is provided, then field is taken from the end of the str
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !CUT
 what: "Apple,Orange,Melon,Citrus,Pear"
 delimiter: ","
 field: 2
-{% endhighlight %}
+```
 
 Will return value "Melon".
 
 
-{% highlight yaml %}
+```yaml
 !CUT
 what: "Apple,Orange,Melon,Citrus,Pear"
 delimiter: ","
 field: -2
-{% endhighlight %}
+```
 
 Will return value "Citrus".
 
   
 ---
 
-## `!SPLIT`: Split a string into the list {#EXPR-SPLIT}
+## `!SPLIT`: Split a string into the list 
 
 Type: _Mapping_
 
@@ -264,12 +264,12 @@ Splits a string into a list of strings.
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !SPLIT
 what: <string>
 delimiter: <string>
 maxsplit: <number>
-{% endhighlight %}
+```
 
 The argument `what` string will be split using a `delimiter` argument.
 An optional `maxsplit` arguments specifies how many splits to do.
@@ -277,28 +277,28 @@ An optional `maxsplit` arguments specifies how many splits to do.
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !SPLIT
 what: "hello,world"
 delimiter: ","
-{% endhighlight %}
+```
 
 ---
 
-## `!JOIN`: Join a list of strings {#EXPR-JOIN}
+## `!JOIN`: Join a list of strings 
 
 Type: _Mapping_
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !JOIN
 items:
   - <...>
   - <...>
 delimiter: <string>
 miss: ''
-{% endhighlight %}
+```
 
 Default `delimiter` is space (" ").
 
@@ -307,10 +307,10 @@ If `miss` is `None` and  any of `items` is `None`, the result of the whole join 
 
 ### Example
 
-{% highlight yaml %}
+```yaml
 !JOIN
 items:
   - "Foo"
   - "Bar"
 delimiter: ','
-{% endhighlight %}
+```

--- a/docs/expression/tuple.md
+++ b/docs/expression/tuple.md
@@ -13,19 +13,19 @@ A tuple is a collection of items, possibly of different types.
 
 --- 
 
-## `!TUPLE`: A collection of items {#EXPR-TUPLE}
+## `!TUPLE`: A collection of items 
 
 Type:  _Mapping_.
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !TUPLE
 with:
   - ...
   - ...
   ...
-{% endhighlight %}
+```
 
 There is no limit of the number of items in the tuple.
 The order of the items is preserved.
@@ -33,58 +33,58 @@ The order of the items is preserved.
 
 ### Examples
 
-{% highlight yaml %}
+```yaml
 !TUPLE
 with:
   - John Doe
   - 37
   - 175.4
-{% endhighlight %}
+```
 
 
 Use of the `!!tuple` notation:
 
-{% highlight yaml %}
+```yaml
 !!tuple
 - 1
 - a
 - 1.2
-{% endhighlight %}
+```
 
 
 Even more concise version of the `!!tuple` using flow syntax:
 
-{% highlight yaml %}
+```yaml
 !!tuple ['John Doe', 37, 175.4]
-{% endhighlight %}
+```
 
 
 Enforce specific type of the item:
 
-{% highlight yaml %}
+```yaml
 !TUPLE
 with:
   - John Doe
   - !!ui8 37
   - 175.4
-{% endhighlight %}
+```
 
 Item #1 will have a type `ui8`.
 
 
 --- 
 
-## `!GET`: Get the item from a tuple {#EXPR-TUPLE-GET}
+## `!GET`: Get the item from a tuple 
 
 Type: _Mapping_.
 
 ### Synopsis
 
-{% highlight yaml %}
+```yaml
 !GET
 what: <index of the item>
 from: <tuple>
-{% endhighlight %}
+```
 
 `what` is an integer (number), it represent the _index_ in a tuple.
 `what` can be negative, in that case, it specifies an item from the end of the list.
@@ -94,7 +94,7 @@ If the `what` is out of bound of the list, the statement returns with error.
 
 ### Examples
 
-{% highlight yaml %}
+```yaml
 !GET
 what: 1
 from:
@@ -103,14 +103,14 @@ from:
     - John Doe
     - 32
     - 127.5
-{% endhighlight %}
+```
 
 Returns `32`.
 
 
 Using the _negative index_ of items:
 
-{% highlight yaml %}
+```yaml
 !GET
 what: -1
 from:
@@ -119,6 +119,6 @@ from:
     - John Doe
     - 32
     - 127.5
-{% endhighlight %}
+```
 
 Returns `127.5`.

--- a/docs/expression/utility.md
+++ b/docs/expression/utility.md
@@ -9,7 +9,7 @@ title: Utility expressions
 
 ---
 
-## `!CAST`: Convert type of the argument into another {#EXPR-CAST}
+## `!CAST`: Convert type of the argument into another 
 
 Type: _Mapping_.
 
@@ -43,7 +43,7 @@ This is an explicit casting of the string into a floating-point number.
 
 ---
 
-## `!HASH`: Calculate a digest {#EXPR-HASH}
+## `!HASH`: Calculate a digest 
 
 Type: _Mapping_.
 
@@ -82,7 +82,7 @@ seed: 5
 
 ---
 
-## `!DEBUG`: Debug the expression {#EXPR-DEBUG}
+## `!DEBUG`: Debug the expression 
 
 Type: _Mapping_.
 

--- a/docs/language/type-system.md
+++ b/docs/language/type-system.md
@@ -329,17 +329,17 @@ A [Python list](https://docs.python.org/3/c-api/list.html).
 
 Use `!CAST` expression for change of the type of a value.
 
-{% highlight yaml %}
+```yaml
 !CAST
 what: 1234
 type: fp32
-{% endhighlight %}
+```
 
 or an equivalent shortcut:
 
-{% highlight yaml %}
+```yaml
 !!fp32 1234
-{% endhighlight %}
+```
 
 Note: Cast is also a great helper for type inference, it means that it could be used to indicate the the type explicitly, if needed.
 


### PR DESCRIPTION
```
import os
import re
import argparse
import logging

"""
This script corrects blocks of codes...
https://squidfunk.github.io/mkdocs-material/reference/code-blocks/

...and removes the old headings IDs
https://www.markdownguide.org/extended-syntax/#heading-ids
"""

logging.basicConfig(level=logging.INFO)


def main(docs_path):
    docs_path = os.path.abspath(docs_path)
    for dirpath, dirnames, filenames in os.walk(docs_path):
        for file in filenames:
            if not file.endswith(".md"):
                continue
            logging.info(f"Working with {file}")
            with open(dirpath + "/" + file, "r") as file_input:
                old_file = file_input.readlines()
                new_text = ""

                while len(old_file) > 0:
                    line = old_file.pop(0)
                    logging.info("Old line {}".format(line))

                    # Check if its a codeblock's beginning or end.
                    if line == '{% highlight yaml %}\n':
                        line = '```yaml\n'
                    if line == '{% endhighlight %}\n':
                        line = '```\n'

                    # Check for a leftover header ID.
                    pattern = '{#EXPR-.*}'
                    line = re.sub(pattern, '', line)

                    logging.info("New line {}".format(line))
                    new_text += line

            with open(dirpath + "/" + file, "w") as file_output:
                file_output.write(new_text)


if __name__ == "__main__":
    parser = argparse.ArgumentParser(prog='MkDocs Migration Helper')
    parser.add_argument('docs_folder', default="splang-docs/docs/")
    args = parser.parse_args()
    logging.info("The files we want to check are here: {}".format(args.docs_folder))
    main(docs_path=args.docs_folder)
```