### PR TITLE
Proofreading the Czech translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_store
 output
 .idea/
+.vscode

--- a/cs/docs/dedication.md
+++ b/cs/docs/dedication.md
@@ -6,7 +6,7 @@ title: Věnování
 # Věnování
 
 Tato práce je věnována památce mé matky, jejíž víra ve mne byla stejně pevná jako bezpodmínečná.
-Ačkoli technická stránka návrhu doménového jazyka byla nad její síly, její neochvějná víra ve mne byla majákem, který mě provázel.
+Ačkoli technická stránka návrhu doménového jazyka byla mimo její sféru, její neochvějná víra ve mne byla majákem, který mě provázel.
 
 Její duch, láska a houževnatost ve mně zůstávají, inspirují mě a pohání kupředu.
 Doufám, že tento jazyk, výtvor mé práce a lásky, je svědectvím jejího nezdolného ducha.

--- a/cs/docs/expressions/aggregate.md
+++ b/cs/docs/expressions/aggregate.md
@@ -21,7 +21,7 @@ Typ: _Sequence_
 	Více informací o [aritmetickém průměru](https://cs.wikipedia.org/wiki/Aritmetick%C3%BD_pr%C5%AFm%C4%9Br) na Wikipedii.
 	
 
-!!! example
+!!! example "Příklad"
 
 	```yaml
 	
@@ -41,7 +41,7 @@ Vrací maximální hodnotu z posloupnosti.
 
 Typ: _Sequence_
 
-!!! example
+!!! example "Příklad"
 
 	```yaml
 	!MAX
@@ -63,7 +63,7 @@ Vrací minimální hodnotu z posloupnosti.
 
 Typ: _Sequence_
 
-!!! example
+!!! example "Příklad"
 
 	```yaml
 	!MIN
@@ -85,7 +85,7 @@ Spočítá počet položek v seznamu.
 
 Typ: _Sequence_
 
-!!! example
+!!! example "Příklad"
 
 	```yaml
 	!COUNT
@@ -118,7 +118,7 @@ Typ: _Sequence_
 	Více informací o [medián](https://cs.wikipedia.org/wiki/Medi%C3%A1n) na Wikipedii.
 	
 
-!!! example
+!!! example "Příklad"
 
 	```yaml
 	!MEDIAN
@@ -145,7 +145,7 @@ Typ: _Sequence_
 	Více informací o [mode](https://cs.wikipedia.org/wiki/Modus) na Wikipedii.
 
 
-!!! example
+!!! example "Příklad"
 
 	```yaml
 	!MODE
@@ -173,7 +173,7 @@ Typ: _Sequence_
 	Více informací o [range](https://cs.wikipedia.org/wiki/Varia%C4%8Dn%C3%AD_rozp%C4%9Bt%C3%AD) na Wikipedii.
 	
 
-!!! example
+!!! example "Příklad"
 
 	```yaml
 	!RANGE

--- a/cs/docs/expressions/aggregate.md
+++ b/cs/docs/expressions/aggregate.md
@@ -1,33 +1,28 @@
 ---
 git_commit_hash: b55fa3f
-title: Agregát
+title: Agregační
 ---
 
-# Souhrnné výrazy
+# Agregační výrazy
 
 Agregační výraz je typ funkce, která provádí výpočty nad množinou hodnot a jako výsledek vrací jednu hodnotu.
 Tyto výrazy se běžně používají k shrnutí nebo zhuštění dat.
 
 ---
 
-## `!AVG`: Průměr 
+## `!AVG`: Průměr (aritmetický průměr)
 
-Vypočítá průměr / aritmetický průměr.
+Vypočítá aritmetický průměr.
 
-Typ: _Posloupnost_
+Typ: _Sequence_
 
 !!! info
 
-	
-	
-	
-	Více informací o [aritmetickém průměru](https://en.wikipedia.org/wiki/Arithmetic_mean) na Wikipedii.
+	Více informací o [aritmetickém průměru](https://cs.wikipedia.org/wiki/Aritmetick%C3%BD_pr%C5%AFm%C4%9Br) na Wikipedii.
 	
 
 !!! example
 
-	
-	
 	```yaml
 	
 	!AVG
@@ -36,12 +31,11 @@ Typ: _Posloupnost_
 	- 4
 	```
 	
-	Výpočet průměru `(6+2+4)/3`, výsledek je `3`.
-	
+	Výpočet průměru `(6+2+4)/3`, výsledek je `4`.
 
 ---
 
-## `!MAX`: Maximální 
+## `!MAX`: Maximum
 
 Vrací maximální hodnotu z posloupnosti.
 
@@ -49,10 +43,7 @@ Typ: _Sequence_
 
 !!! example
 
-	
-	
 	```yaml
-	
 	!MAX
 	- 1.5
 	- 2.6
@@ -61,12 +52,12 @@ Typ: _Sequence_
 	- 4.45
 	```
 	
-	Výsledek tohoto výrazu je `5,1`.
+	Výsledek tohoto výrazu je `5.1`.
 	
 
 ---
 
-## `!MIN`: Minimální 
+## `!MIN`: Minimum
 
 Vrací minimální hodnotu z posloupnosti.
 
@@ -74,10 +65,7 @@ Typ: _Sequence_
 
 !!! example
 
-	
-	
 	```yaml
-	
 	!MIN
 	- 2.6
 	- 3.05
@@ -86,62 +74,52 @@ Typ: _Sequence_
 	- 5.1
 	```
 	
-	Výsledek tohoto výrazu je `0,5`.
+	Výsledek tohoto výrazu je `0.5`.
 	
 
 ---
 
-## `!COUNT`: Počítejte počet položek 
+## `!COUNT`: Počet poležek
 
-Spočítá počet položek v kontejneru.
+Spočítá počet položek v seznamu.
 
 Typ: _Sequence_
 
 !!! example
 
-	
-	
 	```yaml
-	
 	!COUNT
 	- Frodo Pytlík
-	- Sam Gamgee
+	- Samvěd Křepelka
 	- Gandalf
 	- Legolas
 	- Gimli
 	- Aragorn
 	- Boromir z Gondoru
-	- Smíšek Brandybuck
-	- Pipin Took
+	- Smělmír Brandorád
+	- Pipin Bral
 	```
 	
-	Vrací `9`.
+	Výsledek tohoto výrazu je `9`.
 	
 
 ---
 
-## `!MEDIAN`: Střední hodnota 
+## `!MEDIAN`: Medián (prostřední hodnota)
 
 Medián je prostřední hodnota v seznamu čísel; polovina hodnot je větší než medián a polovina je menší než medián.
-Pokud má seznam sudý počet prvků, je medián průměrem dvou středních hodnot.
+Pokud má seznam sudý počet prvků, je medián aritmetickým průměrem dvou prostředních hodnot.
 
-Typ: Typ: _Posloupnost_
+Typ: _Sequence_
 
 
 !!! info
 
+	Více informací o [medián](https://cs.wikipedia.org/wiki/Medi%C3%A1n) na Wikipedii.
 	
-	
-	
-	Více informací o [medián](https://en.wikipedia.org/wiki/Median) na Wikipedii.
-	
-	
-
 
 !!! example
 
-	
-	
 	```yaml
 	!MEDIAN
 	- 1
@@ -151,65 +129,52 @@ Typ: Typ: _Posloupnost_
 	- 101
 	```
 	
+	Výsledek výrazu je `4`.
 
 ---
 
-## `!MODE`: Hodnota, která se objevuje nejčastěji 
+## `!MODE`: Modus (hodnota vyskytující se nejčastěji)
 
-Mode je hodnota nebo hodnoty, které se v seznamu vyskytují nejčastěji.
-Lze jej použít k vyjádření centrální tendence souboru dat.
+Modus je označení pro hodnotu nebo hodnoty, které se v seznamu vyskytují nejčastěji.
+Lze ji použít k vyjádření centrální tendence souboru dat.
 
-Typ: _Posloupnost_
+Typ: _Sequence_
 
 !!! info
 
-	
-	
-	
-	Více informací o [mode](https://en.wikipedia.org/wiki/Mode_%28statistics%29) na Wikipedii.
-	
-	
+	Více informací o [mode](https://cs.wikipedia.org/wiki/Modus) na Wikipedii.
 
 
 !!! example
 
-	
-	
 	```yaml
 	!MODE
-	- -10
-	- -10
+	- 10
+	- 10
 	- -20
 	- -20
-	- 1
-	- 2
-	- 3
-	- 4
-	- 5
+	- 6
+	- 10
 	```
+
+	Výsledek výrazu je `10`.
 	
 
 ---
 
 ## `!RANGE`: Rozdíl mezi největší a nejmenší hodnotou 
 
-Vypočítá rozdíl mezi největší a nejmenší hodnotou.
+Range určuje rozdíl mezi největší a nejmenší hodnotou. V češtině je pro něj též užívaný termín "variační rozpětí".
 
-Typ: Typ: _Posloupnost_
+Typ: _Sequence_
 
 !!! info
 
+	Více informací o [range](https://cs.wikipedia.org/wiki/Varia%C4%8Dn%C3%AD_rozp%C4%9Bt%C3%AD) na Wikipedii.
 	
-	
-	
-	Více informací o [range](https://en.wikipedia.org/wiki/Range_%28statistics%29) na Wikipedii.
-	
-
 
 !!! example
 
-	
-	
 	```yaml
 	!RANGE
 	- 1
@@ -218,4 +183,3 @@ Typ: Typ: _Posloupnost_
 	- 20
 	- -1
 	```
-

--- a/cs/docs/expressions/aggregate.md
+++ b/cs/docs/expressions/aggregate.md
@@ -79,7 +79,7 @@ Typ: _Sequence_
 
 ---
 
-## `!COUNT`: Počet poležek
+## `!COUNT`: Počet položek
 
 Spočítá počet položek v seznamu.
 

--- a/cs/docs/expressions/arithmetics.md
+++ b/cs/docs/expressions/arithmetics.md
@@ -170,7 +170,7 @@ Vypočítá absolutní hodnotu vstupu `x`, což je nezáporná hodnota `x` bez o
 
 	```yaml
 	!ABS
-	co: -8,5
+	what: -8,5
 	```
 	
 	Výsledkem je hodnota `8.5`.

--- a/cs/docs/expressions/arithmetics.md
+++ b/cs/docs/expressions/arithmetics.md
@@ -1,6 +1,6 @@
 ---
 git_commit_hash: b55fa3f
-title: Aritmetika
+title: Aritmetické
 ---
 
 # Aritmetické výrazy

--- a/cs/docs/expressions/arithmetics.md
+++ b/cs/docs/expressions/arithmetics.md
@@ -23,7 +23,7 @@ Výraz je definovaný pro následující typy:
  * Records (záznamy)
 
 
-!!! example
+!!! example "Příklad"
 
 	```yaml
 	!ADD
@@ -40,7 +40,7 @@ Výraz je definovaný pro následující typy:
 
 Typ: _Sequence_
 
-!!! example
+!!! example "Příklad"
 
 	```yaml
 	!SUB
@@ -58,7 +58,7 @@ Typ: _Sequence_
 
 Typ: _Sequence_
 
-!!! example
+!!! example "Příklad"
 
     ```yaml
     !MUL
@@ -75,7 +75,7 @@ Typ: _Sequence_
 
 Typ: _Sequence_
 
-!!! example
+!!! example "Příklad"
 
 	```yaml
 	!DIV
@@ -114,7 +114,7 @@ Vypočítá znaménkový zbytek dělení (neboli výsledek operace modulo).
 
 	Více informací o operaci [modulo](https://cs.wikipedia.org/wiki/Zbytek_po_d%C4%9Blen%C3%AD) na Wikipedii.
 
-!!! example
+!!! example "Příklad"
 
 	```yaml
 	!MOD
@@ -124,7 +124,7 @@ Vypočítá znaménkový zbytek dělení (neboli výsledek operace modulo).
 
 	Vypočítá `21 mod 4`, výsledkem je `1`.
 
-!!! example
+!!! example "Příklad"
 
 	```yaml
 	!MOD
@@ -142,7 +142,7 @@ Typ: _Sequence_
 
 Výpočet exponentu.
 
-!!! example
+!!! example "Příklad"
 
 	```yaml
 	!POW
@@ -166,7 +166,7 @@ what: <x>
 
 Vypočítá absolutní hodnotu vstupu `x`, což je nezáporná hodnota `x` bez ohledu na její znaménko.
 
-!!! example
+!!! example "Příklad"
 
 	```yaml
 	!ABS

--- a/cs/docs/expressions/arithmetics.md
+++ b/cs/docs/expressions/arithmetics.md
@@ -13,20 +13,18 @@ title: Aritmetické
 Typ: _Sequence_
 
 
-Můžete přidat následující typy:
+Výraz je definovaný pro následující typy:
 
- * Čísla (celá čísla a floaty)
+ * Čísla (celá čísla a desetinná čísla)
  * Řetězce
- * seznamy
- * Sady
- * Tuply
- * Záznamy
+ * Seznamy
+ * Množiny
+ * Tuples
+ * Records (záznamy)
 
 
 !!! example
 
-	
-	
 	```yaml
 	!ADD
 	- 4
@@ -34,20 +32,16 @@ Můžete přidat následující typy:
 	- 6
 	```
 	
-
-  Vypočítá `4+(-5)+6`, výsledek je `5`.
+	Vypočítá `4+(-5)+6`, výsledek je `5`.
 
 ---
 
-## `!SUB`: SUB: 
+## `!SUB`: Odčítání
 
 Typ: _Sequence_
 
-
 !!! example
 
-	
-	
 	```yaml
 	!SUB
 	- 3
@@ -55,6 +49,7 @@ Typ: _Sequence_
 	- -5
 	```
 	
+	Vypočítá `3-1-(-5)`, výsledkem je `7`.
 
 ---
 
@@ -63,36 +58,32 @@ Typ: _Sequence_
 
 Typ: _Sequence_
 
-
 !!! example
 
+    ```yaml
+    !MUL
+    - 7
+    - 11
+    - 13
+    ```
 	
-	
-	```yaml
-	!MUL
-	- 1.5
-	- 5.5
-	- 3.2
-	```
-	
+	Vypočítá `7*11*13`, výsledkem je `1001` (což je shodou okolností [Šahrazádino číslo](https://cs.wikipedia.org/wiki/Tis%C3%ADc_a_jedna_noc)).
 
 ---
 
-## `!DIV`: Division 
+## `!DIV`: Dělení
 
-Typ: DIV _Sequence_
-
+Typ: _Sequence_
 
 !!! example
 
-	
-	
 	```yaml
 	!DIV
 	- 21
 	- 1.5
 	```
 	
+	Vypočítá `21/1.5`, výsledkem je `14.0`.
 	
 
 ### Dělení nulou
@@ -106,32 +97,42 @@ Druhou položkou je hodnota, která bude vrácena, pokud k takové chybě dojde.
 
 !TRY
 - !DIV
-  - !ARG vstup
+  - !ARG input
   - 0.0
 - 5.0
 ```
 
-
 ---
 
-## `!MOD`: Připomínka 
+## `!MOD`: Zbytek po dělení (modulo)
 
 Typ: _Sequence_
 
+Vypočítá znaménkový zbytek dělení (neboli výsledek operace modulo).
 
-Vypočítá znaménkový zbytek dělení (neboli operace modulo).
+!!! info
 
+	Více informací o operaci [modulo](https://cs.wikipedia.org/wiki/Zbytek_po_d%C4%9Blen%C3%AD) na Wikipedii.
 
 !!! example
 
-	
-	
 	```yaml
 	!MOD
 	- 21
-	- 1.5
+	- 4
 	```
-	
+
+	Vypočítá `21 mod 4`, výsledkem je `1`.
+
+!!! example
+
+	```yaml
+	!MOD
+	- -10
+	- 3
+	```
+
+	Vypočítá `-10 mod 3`, výsledkem je `2`.
 
 ---
 
@@ -139,43 +140,38 @@ Vypočítá znaménkový zbytek dělení (neboli operace modulo).
 
 Typ: _Sequence_
 
-
 Výpočet exponentu.
-
 
 !!! example
 
-	
-	
 	```yaml
 	!POW
 	- 2
 	- 8
 	```
 	
+	Vypočítá `2^8`, výsledkem je `16`.
 
 ---
 
 ## `!ABS`: Absolutní hodnota
 
-Typ: _Mapování_
+Typ: _Mapping_
+
 ```yaml
 
 !ABS
-co: <x>
+what: <x>
 ```
 
-Vypočítejte absolutní hodnotu vstupu `x`, což je nezáporná hodnota `x` bez ohledu na její znaménko.
+Vypočítá absolutní hodnotu vstupu `x`, což je nezáporná hodnota `x` bez ohledu na její znaménko.
 
 !!! example
 
-	
-	
 	```yaml
-	
 	!ABS
 	co: -8,5
 	```
 	
-	Výsledkem je hodnota `8,5`.
+	Výsledkem je hodnota `8.5`.
 

--- a/cs/docs/expressions/bitwise.md
+++ b/cs/docs/expressions/bitwise.md
@@ -1,6 +1,6 @@
 ---
 git_commit_hash: b55fa3f
-title: Bitově
+title: Bitové
 ---
 
 # Bitové výrazy

--- a/cs/docs/expressions/bitwise.md
+++ b/cs/docs/expressions/bitwise.md
@@ -8,7 +8,7 @@ title: Bitové
 Bitové posuny ("bit shifts") zachází s hodnotou jako se sérií bitů, umožňuje přesunout nebo posunout binární číslice doleva nebo doprava.
 
 
-Existují také bitové výrazy `!AND`, `!OR` a `!NOT`, v kapitole [Logické výrazy](../logic).
+Existují také bitové výrazy `!AND`, `!OR` a `!NOT`, viz kapitolu [Logické výrazy](../logic).
 
 ---
 
@@ -101,7 +101,7 @@ by: <...>
 
 ---
 
-## `!ROL`: (kruhový) posun doleva 
+## `!ROL`: Kruhový posun doleva 
 
 Typ: _Mapping_.
 ```yaml
@@ -114,7 +114,7 @@ by: <...>
 
 ---
 
-## `!ROR`: Pravý rotační (kruhový) posun 
+## `!ROR`: Kruhový posun doprava
 
 Typ: _Mapping_.
 ```yaml

--- a/cs/docs/expressions/bitwise.md
+++ b/cs/docs/expressions/bitwise.md
@@ -3,109 +3,88 @@ git_commit_hash: b55fa3f
 title: Bitové
 ---
 
-# Bitové výrazy
+# Bitové operace
+
+Bitové posuny ("bit shifts") zachází s hodnotou jako se sérií bitů, umožňuje přesunout nebo posunout binární číslice doleva nebo doprava.
 
 
-Bitové posuny zachází s hodnotou jako s řadou bitů, binární číslice hodnoty jsou přesunuty nebo posunuty doleva nebo doprava.
-
-
-Existují také bitové výrazy `!AND`, `!OR` a `!NOT`, v kapitole [Logika](../logika).
+Existují také bitové výrazy `!AND`, `!OR` a `!NOT`, v kapitole [Logické výrazy](../logic).
 
 ---
 
-## `!SHL`: Levý logický posun 
+## `!SHL`: Logický posun doleva 
 
-Typ: _Mapování_.
+Typ: _Mapping_.
+
 ```yaml
-
 !SHL
-co: <...>
+what: <...>
 by: <...>
 ```
 
 !!! tip
 
-	
-	
-	
 	Levý posun lze použít jako rychlé násobení čísly 2, 4, 8 atd.
-	
-	
 
 !!! example
 
-	
-	
 	```yaml
-	
 	!SHL
-	co: 60
-	podle: 2
+	what: 9
+	by: 2
 	```
-	
-	Výsledek je: `240 = (60*2^2)`, `2^2 = 4`.
+
+	`9` je reprezentovaná binární hodnotou `1001`. Levý logický posun posune bity doleva o 2 pozice. Výsledkem je `100100`, což je v desítkovém zápise `36`. To je  `9 * (2^2)`. To je stejný výsledek jako `9 * (2^2)`.
 	
 
 ---
 
-## `!SHR`: Pravý logický posun  
+## `!SHR`: Logický posun doprava 
 
-Typ: _Mapování_.
+Typ: _Mapping_.
+
 ```yaml
 
 !SHR
-co: <...>
+what: <...>
 by: <...>
 ```
 
 !!! tip
 
-	
-	
-	
-	Pravý posun lze použít jako rychlé dělení číslem 2, 4, 8 atd.
-	
-	
+	Pravý posun lze použít jako rychlé dělení čísly 2, 4, 8 atd.
+
 
 !!! example
 
-	
-	
 	```yaml
-	
 	!SHR
-	co: 2048
-	by: 4
+	what: 16
+	by: 3
 	```
-	
-	Výsledek je: `128 = (2048/2^4)`, `2^4 = 16`.
-	
-	
+
+	`16` je reprezentovaná `10000`. Logický posun posune bity doprava o `3`. Výsledkem je `10`, tedy `2` v desítkovém zápisu. To je stejný výsledek jako `16 / (2^3)`.
 
 --- 
 
-## `!SAL`: Levý aritmetický posun 
+## `!SAL`: Aritmetický posun doleva
 
 Typ: _Mapping_.
-```yaml
 
+```yaml
 !SAL
-co: <...>
+what: <...>
 by: <...>
 ```
 
-
 !!! example
 
-	
-	
 	```yaml
 	!SAL
-	co: 60
-	podle: 2
+	what: 60
+	by: 2
 	```
-	
-	
+
 
 ---
 
@@ -115,7 +94,7 @@ Typ: _Mapping_.
 ```yaml
 
 !SAR
-co: <...>
+what: <...>
 by: <...>
 ```
 
@@ -128,7 +107,7 @@ Typ: _Mapping_.
 ```yaml
 
 !ROL
-co: <...>
+what: <...>
 by: <...>
 ```
 
@@ -141,6 +120,6 @@ Typ: _Mapping_.
 ```yaml
 
 !ROR
-co: <...>
+what: <...>
 by: <...>
 ```

--- a/cs/docs/expressions/bitwise.md
+++ b/cs/docs/expressions/bitwise.md
@@ -26,7 +26,7 @@ by: <...>
 
 	Levý posun lze použít jako rychlé násobení čísly 2, 4, 8 atd.
 
-!!! example
+!!! example "Příklad"
 
 	```yaml
 	!SHL
@@ -55,7 +55,7 @@ by: <...>
 	Pravý posun lze použít jako rychlé dělení čísly 2, 4, 8 atd.
 
 
-!!! example
+!!! example "Příklad"
 
 	```yaml
 	!SHR
@@ -77,7 +77,7 @@ what: <...>
 by: <...>
 ```
 
-!!! example
+!!! example "Příklad"
 
 	```yaml
 	!SAL

--- a/cs/docs/expressions/comparisons.md
+++ b/cs/docs/expressions/comparisons.md
@@ -11,7 +11,7 @@ Testovací výraz vyhodnotí vstupy a na základě výsledku testu vrátí logic
 
 ## `!EQ`: Rovná se 
 
-!!! example
+!!! example "Příklad"
 
 	```yaml
 	!EQ
@@ -30,7 +30,7 @@ Typ: _Sequence_.
 
 Jedná se o zápornou obdobu `!EQ`.
 
-!!! example
+!!! example "Příklad"
 
 	```yaml
 	!NE
@@ -46,7 +46,7 @@ Jedná se o zápornou obdobu `!EQ`.
 
 Typ: _Sequence_.
 
-!!! example
+!!! example "Příklad"
 
 	```yaml
 	!LT
@@ -64,7 +64,7 @@ Typ: _Sequence_.
 
 Typ: _Sequence_.
 
-!!! example
+!!! example "Příklad"
 
 	```yaml
 	!LE
@@ -82,7 +82,7 @@ Typ: _Sequence_.
 
 Typ: _Sequence_.
 
-!!! example
+!!! example "Příklad"
 
 	```yaml
 	!GT [!ARG count, 5]
@@ -96,7 +96,7 @@ Typ: _Sequence_.
 
 Typ: _Sequence_.
 
-!!! example
+!!! example "Příklad"
 
 	```yaml
 	!GT
@@ -122,7 +122,7 @@ Výraz `!IN` se používá ke kontrole, zda hodnota `what` existuje v hodnotě `
 Jako hodnotu `where` lze uvést řetězec, kontejner (seznam, množina, slovník), strukturní typ atd.
 Vyhodnotí se na `true`, pokud najde hodnotu `what` v zadané hodnotě `where`, a na `false` v opačném případě.
 
-!!! example
+!!! example "Příklad"
 
 	```yaml
 	!IN
@@ -138,7 +138,7 @@ Vyhodnotí se na `true`, pokud najde hodnotu `what` v zadané hodnotě `where`, 
 	Zkontroluje přítomnost hodnoty `5` v seznamu `where`. Vrátí "true".
 
 
-!!! example
+!!! example "Příklad"
 
 	```yaml
 	!IN

--- a/cs/docs/expressions/comparisons.md
+++ b/cs/docs/expressions/comparisons.md
@@ -1,6 +1,6 @@
 ---
 git_commit_hash: b55fa3f
-title: Srovnání
+title: Porovnávací
 ---
 
 # Porovnávací výrazy

--- a/cs/docs/expressions/comparisons.md
+++ b/cs/docs/expressions/comparisons.md
@@ -108,7 +108,7 @@ Typ: _Sequence_.
 
 ---
 
-## `!IN`: Test členství 
+## `!IN`: Test výskytu
 
 Typ: _Mapping_.
 
@@ -118,7 +118,7 @@ what: <...>
 where: <...>
 ```
 
-Výraz `!IN` se používá ke kontrole, zda hodnota `what` existuje v hodnotě `where`, nebo ne.
+Výraz `!IN` se používá ke kontrole, zda hodnota se `what` vyskytuje v hodnotě `where`, nebo ne.
 Jako hodnotu `where` lze uvést řetězec, kontejner (seznam, množina, slovník), strukturní typ atd.
 Vyhodnotí se na `true`, pokud najde hodnotu `what` v zadané hodnotě `where`, a na `false` v opačném případě.
 
@@ -135,7 +135,7 @@ Vyhodnotí se na `true`, pokud najde hodnotu `what` v zadané hodnotě `where`, 
 	  - 5
 	```
 	
-	Zkontroluje přítomnost hodnoty `5` v seznamu `where`. Vrátí "true".
+	Zkontroluje přítomnost hodnoty `5` v seznamu `where`. Vrátí `true`.
 
 
 !!! example "Příklad"
@@ -146,5 +146,5 @@ Vyhodnotí se na `true`, pokud najde hodnotu `what` v zadané hodnotě `where`, 
 	where: "John Willy Boo"
 	```
 	
-	Zkontroluje přítomnost podřetězce `Willy` v hodnotě `John Willy Boo`. Vrací hodnotu "true".
+	Zkontroluje přítomnost podřetězce `Willy` v hodnotě `John Willy Boo`. Vrátí `true`.
 

--- a/cs/docs/expressions/comparisons.md
+++ b/cs/docs/expressions/comparisons.md
@@ -5,94 +5,76 @@ title: Porovnávací
 
 # Porovnávací výrazy
 
-
-Testovací výraz vyhodnotí vstupy a na základě výsledku testu vrátí logickou hodnotu `pravda` nebo `nepravda`.
+Testovací výraz vyhodnotí vstupy a na základě výsledku testu vrátí logickou hodnotu `true` nebo `false`.
 
 ---
 
 ## `!EQ`: Rovná se 
 
-
 !!! example
 
-	
-	
 	```yaml
-	
 	!EQ
-	- !ARG počet
+	- !ARG count
 	- 3
 	```
 	
-	Porovná argument `count` s `3`.
-	
-	
+	Porovnává argument `count` s `3`, vrací `count == 3`.
+
 
 ---
 
-## `!NE`: Není rovno 
+## `!NE`: Nerovná se
 
 Typ: _Sequence_.
 
 Jedná se o zápornou obdobu `!EQ`.
 
-
-
 !!! example
 
-	
-	
 	```yaml
 	!NE
-	- !ARG název
+	- !ARG name
 	- Frodo
 	```
-	
-	
+
+	Porovnává argument `name` s `Frodo`, vrací `name != Frodo`.
 
 ---
 
-## `!LT`: Méně než 
+## `!LT`: Menší než
 
 Typ: _Sequence_.
 
 !!! example
 
-	
-	
 	```yaml
-	
 	!LT
-	- !ARG počet
+	- !ARG count
 	- 5
 	```
 	
-	Příklad testu `count &lt; 5`.
+	Příklad testu `count < 5`.
 	
 	
 
 ---
 
-## `!LE`: Méně než a rovno 
+## `!LE`: Menší nebo rovno
 
 Typ: _Sequence_.
 
-
 !!! example
 
-	
-	
 	```yaml
-	
 	!LE
 	- 2
 	- !ARG počet
 	- 5
 	```
 	
-	Příklad testu rozsahu `2 &lt;= count &lt;= 5`.
-	
-	
+	Příklad testu rozsahu `2 <= count <= 5`.
+
 
 ---
 
@@ -102,63 +84,50 @@ Typ: _Sequence_.
 
 !!! example
 
-	
-	
 	```yaml
-	
 	!GT [!ARG count, 5]
 	```
 	
-	Příklad testu `count &gt; 5` pomocí zhuštěného tvaru YAML.
-	
-	
+	Příklad testu `count >  5` pomocí kompaktní formy YAMLu.
 
 ---
 
-## `!GE`: Větší než a rovná se 
+## `!GE`: Větší nebo rovno
 
 Typ: _Sequence_.
 
 !!! example
 
-	
-	
 	```yaml
-	
 	!GT
-	- !ARG počet
+	- !ARG count
 	- 5
 	```
 	
-	Příklad testu `count &gt;= 5`.
-	
-	
+	Příklad testu `count >= 5`.
 
 ---
 
 ## `!IN`: Test členství 
 
 Typ: _Mapping_.
-```yaml
 
+```yaml
 !IN
-co: <...>
-kde: <...>
+what: <...>
+where: <...>
 ```
 
 Výraz `!IN` se používá ke kontrole, zda hodnota `what` existuje v hodnotě `where`, nebo ne.
-Hodnota `where` je řetězec, kontejner (seznam, množina, slovník), strukturní typ atd.
-Vyhodnotí se na "true", pokud najde hodnotu `what` v zadané hodnotě `where`, a na false v opačném případě.
+Jako hodnotu `where` lze uvést řetězec, kontejner (seznam, množina, slovník), strukturní typ atd.
+Vyhodnotí se na `true`, pokud najde hodnotu `what` v zadané hodnotě `where`, a na `false` v opačném případě.
 
 !!! example
 
-	
-	
 	```yaml
-	
 	!IN
-	co: 5
-	kde:
+	what: 5
+	where:
 	  - 1
 	  - 2
 	  - 3
@@ -166,20 +135,16 @@ Vyhodnotí se na "true", pokud najde hodnotu `what` v zadané hodnotě `where`, 
 	  - 5
 	```
 	
-	Zkontroluje přítomnost hodnoty `5` v seznamu `where`. Vrací hodnotu "true".
-	
-	
+	Zkontroluje přítomnost hodnoty `5` v seznamu `where`. Vrátí "true".
+
 
 !!! example
 
-	
-	
 	```yaml
-	
 	!IN
-	co: "Willy"
-	kde: "John Willy Boo"
+	what: "Willy"
+	where: "John Willy Boo"
 	```
 	
-	Zkontroluje přítomnost podřetězce "Willy" v hodnotě `where`. Vrací hodnotu "true".
+	Zkontroluje přítomnost podřetězce `Willy` v hodnotě `John Willy Boo`. Vrací hodnotu "true".
 

--- a/cs/docs/expressions/control.md
+++ b/cs/docs/expressions/control.md
@@ -100,7 +100,7 @@ Pokud není zadáno `else`, pak `WHEN` vrací `False`.
     # In-set match
     - test:
         !IN
-        co: !ARG key
+        what: !ARG key
         where:
           - 75
           - 77

--- a/cs/docs/expressions/control.md
+++ b/cs/docs/expressions/control.md
@@ -12,62 +12,57 @@ SP-Lang nabízí celou řadu řídicích výrazů.
 
 ## `!IF`: Jednoduché podmíněné větvení  
 
-Typ: _Mapování_.
-
+Typ: _Mapping_.
 
 Výraz `!IF` je rozhodovací výraz, který vede vyhodnocení k rozhodování na základě zadaného testu.
-```yaml
 
+```yaml
 !IF
 test: <expression>
-pak: <expression>
+then: <expression>
 else: <expression>
 ```
 
+Na základě hodnoty `test` se vyhodnotí větev:
 
-Na základě této hodnoty se vyhodnotí větev `then` (pro `true`) nebo `else` (pro `false`).
+- `then` v případě `test !EQ true`
+- `else` v případě `test !EQ false`
 
-`then` a `else` musí vracet stejný typ, který bude zároveň typem návratové hodnoty `!IF`.
-
-
+Oba případy `then` a `else` musejí vracet stejný typ, který bude zároveň typem návratové hodnoty `!IF`.
 
 !!! example
 
-	
-	
 	```yaml
 	!IF
 	test:
 	  !EQ
-	  - !ARG vstup
+	  - !ARG input
 	  - 2
 	pak:
-	  To jsou dva.
+	  It is two.
 	else:
-	  NENÍ to dva.
+	  It is NOT two.
 	```
-	
 
 ---
 
-## `!KDYŽ`: Výkonné větvení  
+## `!WHEN`: Výkonné větvení
 
 Typ: _Sequence_.
 
-Výraz `!KDYŽ` je podstatně silnější než výraz `!IF`.
-Případy mohou odpovídat mnoha různým vzorům, včetně intervalových shod, tuplů atd. 
+Výraz `!WHEN` je podstatně silnější než výraz `!IF`.
+Jednotlivé případy mohou odpovídat mnoha různým vzorům, včetně intervalových shod, tuples atd. 
 
 ```yaml
-
 !WHEN
 - test: <expression>
-  pak: <expression>
+  then: <expression>
 
 - test: <expression>
-  pak: <expression>
+  then: <expression>
 
 - test: <expression>
-  pak: <expression>
+  then: <expression>
 
 - ...
 
@@ -80,10 +75,7 @@ Pokud není zadáno `else`, pak `WHEN` vrací `False`.
 
 !!! example
 
-	
-	
-	
-	Příklad použití `!KDYŽ` pro přesnou shodu, shodu rozsahu a nastavenou shodu:
+	Příklad použití `!WHEN` pro přesnou shodu, shodu rozsahu a nastavenou shodu:
 	```yaml
 	
 	!KDYŽ
@@ -91,53 +83,50 @@ Pokud není zadáno `else`, pak `WHEN` vrací `False`.
 	# Přesná shoda hodnot
 	- test:
 	    !EQ
-	    - !ARG klíč
+	    - !ARG key
 	    - 34
 	  pak:
-	    "Třicet čtyři"
+	    "třicet čtyři"
 	
 	# Shoda rozsahu
 	- test:
 	    !LT
 	    - 40
-	    - !ARG klíč
+	    - !ARG key
 	    - 50
-	  pak:
-	    "čtyřicet až padesát (výhradně)"
+	  then:
+	    "čtyřicet až padesát (bez krajních hodnot)"
 	
 	# In-set match
 	- test:
 	    !IN
-	    co: !ARG klíč
-	    kde:
+	    co: !ARG key
+	    where:
 	      - 75
 	      - 77
 	      - 79
 	  then:
 	    "sedmdesát pět, sedm, devět"
 	
-	
 	- else:
-	    "Neznámý"
+	    "neznámý"
 	```
-	
 
 --- 
 
-## `!MATCH`: Porovnávání vzorů 
+## `!MATCH`: Porovnávání vzorů
 
 Typ: _Mapping_.
 
 ```yaml
-
 !MATCH
-co: <what-expression>
-s:
- <value>: <expression>
+what: <what-expression>
+with:
+  <value>: <expression>
   <value>: <expression>
   ...
 else:
- <expression>
+  <expression>
 ```
 
 Výraz `!MATCH` vyhodnotí výraz `what-expression`, přiřadí hodnotu výrazu k klauzuli case a provede výraz `expression` spojený s tímto případem.
@@ -146,49 +135,38 @@ Větev `else` výrazu `!MATCH` je nepovinná.
 Výraz selže s chybou, pokud není nalezena žádná odpovídající `<value>` a větev `else` chybí.
 
 
-
 !!! example
 
-	
-	
 	```yaml
 	!MATCH
-	co: 1
-	s:
-	  1: "One"
-	  2: "Two"
-	  3: "Three"
+	what: !ARG value
+	with:
+	  1: "jedna"
+	  2: "dva"
+	  3: "tři"
 	else:
-	  "Jiné číslo"
+	  "jiné číslo"
 	```
-	
-	
-
 
 !!! hint "Použití `!MATCH` pro strukturování kódu"
 
-	
-	
 	```yaml
 	!MATCH
-	co: !ARG kód
-	s:
+	what: !ARG kód
+	with:
 	  1: !INCLUDE code-1.yaml
 	  2: !INCLUDE code-2.yaml
 	else:
 	  !INCLUDE code-else.yaml
 	```
 
-  
 ---
 
-## `!TRY`: Provést do prvního bezchybného výrazu  
-
+## `!TRY`: Provádění operací dž do prvního chybného výrazu  
 
 Typ: _Sequence_
+
 ```yaml
-
-
 !TRY
 - <expression>
 - <expression>
@@ -196,7 +174,7 @@ Typ: _Sequence_
 ...
 ```
 
-Iterujte výrazem (shora dolů), pokud výraz vrátí nenulový výsledek (`None`), zastavte iteraci a vraťte tuto hodnotu.
+Iteruje jednotlivými výrazy (odshora dolů), pokud výraz vrátí nenulový výsledek (`None`), zastavte iteraci a vraťte tuto hodnotu.
 V opačném případě pokračujte na další výraz.
 
 Při dosažení konce seznamu vrátí `None` (chyba).

--- a/cs/docs/expressions/control.md
+++ b/cs/docs/expressions/control.md
@@ -200,8 +200,6 @@ Výsledkem je nový seznam s transformovanými prvky.
 
 !!! example "Příklad"
 
-	
-	
 	```yaml
 	
 	!MAP

--- a/cs/docs/expressions/control.md
+++ b/cs/docs/expressions/control.md
@@ -1,12 +1,12 @@
 ---
 git_commit_hash: b55fa3f
-title: Kontrolní
+title: Řídicí
 ---
 
-# Kontrolní výrazy
+# Řídicí výrazy
 
 
-SP-Lang nabízí celou řadu řídicích výrazů. 
+SP-Lang nabízí celou řadu řídicích výrazů.
 
 --- 
 
@@ -38,7 +38,7 @@ Oba případy `then` a `else` musejí vracet stejný typ, který bude zároveň 
 	  !EQ
 	  - !ARG input
 	  - 2
-	pak:
+	then:
 	  It is two.
 	else:
 	  It is NOT two.
@@ -191,7 +191,7 @@ Typ: _Mapování_.
 ```yaml
 
 !MAP
-co: <sequence>
+what: <sequence>
 apply: <expression>
 ```
 

--- a/cs/docs/expressions/control.md
+++ b/cs/docs/expressions/control.md
@@ -30,7 +30,7 @@ Na základě hodnoty `test` se vyhodnotí větev:
 
 Oba případy `then` a `else` musejí vracet stejný typ, který bude zároveň typem návratové hodnoty `!IF`.
 
-!!! example
+!!! example "Příklad"
 
 	```yaml
 	!IF
@@ -73,7 +73,7 @@ Jednotlivé případy mohou odpovídat mnoha různým vzorům, včetně interval
 Pokud není zadáno `else`, pak `WHEN` vrací `False`.
 
 
-!!! example
+!!! example "Příklad"
 
 	Příklad použití `!WHEN` pro přesnou shodu, shodu rozsahu a nastavenou shodu:
 	```yaml
@@ -135,7 +135,7 @@ Větev `else` výrazu `!MATCH` je nepovinná.
 Výraz selže s chybou, pokud není nalezena žádná odpovídající `<value>` a větev `else` chybí.
 
 
-!!! example
+!!! example  "Příklad"
 
 	```yaml
 	!MATCH
@@ -198,13 +198,13 @@ apply: <expression>
 Výraz `apply` se aplikuje na každý prvek v posloupnosti `what` s argumentem `x` obsahujícím příslušnou hodnotu prvku.
 Výsledkem je nový seznam s transformovanými prvky.
 
-!!! example
+!!! example "Příklad"
 
 	
 	
 	```yaml
 	
-	!MAPA
+	!MAP
 	co: [1, 2, 3, 4, 5, 6, 7]
 	použít:
 	  !ADD [!ARG x, 10]
@@ -235,7 +235,7 @@ Výraz `initval` poskytuje počáteční hodnotu pro argument `a`.
 Nepovinná hodnota `fold` určuje "levé skládání" (`left`, výchozí) nebo "pravé skládání" (`right`).
 
 
-!!! example
+!!! example "Příklad"
 
 	
 	

--- a/cs/docs/expressions/control.md
+++ b/cs/docs/expressions/control.md
@@ -32,21 +32,21 @@ Oba případy `then` a `else` musejí vracet stejný typ, který bude zároveň 
 
 !!! example "Příklad"
 
-	```yaml
-	!IF
-	test:
-	  !EQ
-	  - !ARG input
-	  - 2
-	then:
-	  It is two.
-	else:
-	  It is NOT two.
-	```
+    ```yaml
+    !IF
+    test:
+      !EQ
+      - !ARG input
+      - 2
+    then:
+      It is two.
+    else:
+      It is NOT two.
+    ```
 
 ---
 
-## `!WHEN`: Výkonné větvení
+## `!WHEN`: Násobné větvení
 
 Typ: _Sequence_.
 
@@ -75,42 +75,42 @@ Pokud není zadáno `else`, pak `WHEN` vrací `False`.
 
 !!! example "Příklad"
 
-	Příklad použití `!WHEN` pro přesnou shodu, shodu rozsahu a nastavenou shodu:
-	```yaml
-	
-	!KDYŽ
-	
-	# Přesná shoda hodnot
-	- test:
-	    !EQ
-	    - !ARG key
-	    - 34
-	  pak:
-	    "třicet čtyři"
-	
-	# Shoda rozsahu
-	- test:
-	    !LT
-	    - 40
-	    - !ARG key
-	    - 50
-	  then:
-	    "čtyřicet až padesát (bez krajních hodnot)"
-	
-	# In-set match
-	- test:
-	    !IN
-	    co: !ARG key
-	    where:
-	      - 75
-	      - 77
-	      - 79
-	  then:
-	    "sedmdesát pět, sedm, devět"
-	
-	- else:
-	    "neznámý"
-	```
+    Příklad použití `!WHEN` pro přesnou shodu, shodu rozsahu a nastavenou shodu:
+
+    ```yaml
+    !WHEN
+
+    # Přesná shoda hodnot
+    - test:
+        !EQ
+        - !ARG key
+        - 34
+      pak:
+        "třicet čtyři"
+
+    # Shoda rozsahu
+    - test:
+        !LT
+        - 40
+        - !ARG key
+        - 50
+      then:
+        "čtyřicet až padesát (bez krajních hodnot)"
+
+    # In-set match
+    - test:
+        !IN
+        co: !ARG key
+        where:
+          - 75
+          - 77
+          - 79
+      then:
+        "sedmdesát pět, sedm, devět"
+
+    - else:
+        "neznámý"
+    ```
 
 --- 
 
@@ -137,32 +137,32 @@ Výraz selže s chybou, pokud není nalezena žádná odpovídající `<value>` 
 
 !!! example  "Příklad"
 
-	```yaml
-	!MATCH
-	what: !ARG value
-	with:
-	  1: "jedna"
-	  2: "dva"
-	  3: "tři"
-	else:
-	  "jiné číslo"
-	```
+    ```yaml
+    !MATCH
+    what: !ARG value
+    with:
+      1: "jedna"
+      2: "dva"
+      3: "tři"
+    else:
+      "jiné číslo"
+    ```
 
 !!! hint "Použití `!MATCH` pro strukturování kódu"
 
-	```yaml
-	!MATCH
-	what: !ARG kód
-	with:
-	  1: !INCLUDE code-1.yaml
-	  2: !INCLUDE code-2.yaml
-	else:
-	  !INCLUDE code-else.yaml
-	```
+    ```yaml
+    !MATCH
+    what: !ARG kód
+    with:
+      1: !INCLUDE code-1.yaml
+      2: !INCLUDE code-2.yaml
+    else:
+      !INCLUDE code-else.yaml
+    ```
 
 ---
 
-## `!TRY`: Provádění operací dž do prvního chybného výrazu  
+## `!TRY`: Provádění operací dž do prvního bezchybného výrazu  
 
 Typ: _Sequence_
 
@@ -174,22 +174,20 @@ Typ: _Sequence_
 ...
 ```
 
-Iteruje jednotlivými výrazy (odshora dolů), pokud výraz vrátí nenulový výsledek (`None`), zastavte iteraci a vraťte tuto hodnotu.
-V opačném případě pokračujte na další výraz.
+Iteruje jednotlivými výrazy (odshora dolů), pokud výraz vrátí nenulový výsledek (`None`), zastaví iteraci a vrátí tuto hodnotu.
+V opačném případě pokračuje k dalšímu výrazu.
 
 Při dosažení konce seznamu vrátí `None` (chyba).
 
-
-Poznámka: Zastaralý název tohoto výrazu byl `!FIRST`.
-Byl zastaralý v listopadu 2022.
+Poznámka: Zastaralý název tohoto výrazu byl `!FIRST`. Nepoužívá se od listopadu 2022.
     
 ---
 
 ## `!MAP`: Použít výraz na každý prvek v posloupnosti 
 
-Typ: _Mapování_.
-```yaml
+Typ: _Mapping_.
 
+```yaml
 !MAP
 what: <sequence>
 apply: <expression>
@@ -200,52 +198,46 @@ Výsledkem je nový seznam s transformovanými prvky.
 
 !!! example "Příklad"
 
-	```yaml
-	
-	!MAP
-	co: [1, 2, 3, 4, 5, 6, 7]
-	použít:
-	  !ADD [!ARG x, 10]
-	```
-	
-	Výsledek je `[11, 12, 13, 14, 15, 16, 17]`.
-	
+    ```yaml
+    !MAP
+    whaz: [1, 2, 3, 4, 5, 6, 7]
+    apply:
+      !ADD [!ARG x, 10]
+    ```
+
+    Výsledek je `[11, 12, 13, 14, 15, 16, 17]`.
+    
 
 ---
 
 ## `!REDUCE`: Redukce prvků seznamu na jedinou hodnotu 
 
-Typ: _Mapování_.
+Typ: _Mapping_.
 
 ```yaml
-
 !REDUCE
-co: <expression>
-použít: <expression>
+what: <expression>
+apply: <expression>
 initval: <expression>
 fold: <left|right>
 ```
 
-Výraz `apply` se aplikuje na každý prvek v posloupnosti `what` s argumentem `a` obsahujícím agregaci operace reduce a argumentem 'b' obsahujícím příslušnou hodnotu prvku.
+Výraz `apply` se aplikuje na každý prvek v posloupnosti `what` s argumentem `a` obsahujícím agregaci operace reduce a argumentem `b` obsahujícím příslušnou hodnotu prvku.
 
 Výraz `initval` poskytuje počáteční hodnotu pro argument `a`.
 
 Nepovinná hodnota `fold` určuje "levé skládání" (`left`, výchozí) nebo "pravé skládání" (`right`).
 
-
 !!! example "Příklad"
 
-	
-	
-	```yaml
-	
-	!REDUKCE
-	co: [1, 2, 3, 4, 5, 6, 7]
-	initval: -10
-	apply:
-	  !ADD [!ARG a, !ARG b]
-	```
-	
-	Vypočítá součet posloupnosti s počáteční hodnotou -1.  
-	Výsledek je `18` = `-10 + 1 + 2 + 3 + 4 + 5 + 6 + 7`.
+    ```yaml
+    !REDUCE
+    what: [1, 2, 3, 4, 5, 6, 7]
+    initval: -10
+    apply:
+      !ADD [!ARG a, !ARG b]
+    ```
+    
+    Vypočítá součet posloupnosti s počáteční hodnotou `-10`.  
+    Výsledek je `18 = -10 + 1 + 2 + 3 + 4 + 5 + 6 + 7`.
 

--- a/cs/docs/expressions/control.md
+++ b/cs/docs/expressions/control.md
@@ -1,6 +1,6 @@
 ---
 git_commit_hash: b55fa3f
-title: Kontrola
+title: Kontrolní
 ---
 
 # Kontrolní výrazy

--- a/cs/docs/expressions/datetime.md
+++ b/cs/docs/expressions/datetime.md
@@ -6,16 +6,13 @@ title: Datum/čas
 # Výrazy pro datum a čas
 
 
-Datum a čas se v SP-Langu vyjadřuje pomocí typu `datetime`.
-Má mikrosekundové rozlišení a rozsah od roku 8190 př. n. l. do roku 8191.
+Datum a čas se v SP-Langu vyjadřují pomocí typu `datetime`.
+Má mikrosekundové rozlišení a rozsah od roku 8190 př.n.l. do roku 8191.
 Je v časovém pásmu UTC.
 
 !!! info
 
-	
-	
-	
-	Další informace o typu `datatime` najdete [zde](../../language/date-time).
+	Další informace o typu `datetime` najdete [zde](../../language/date-time).
 	
 
 ---
@@ -24,163 +21,146 @@ Je v časovém pásmu UTC.
 
 Typ: _Mapping_.
 
-Získání aktuálního data a času.
-```yaml
+Získá aktuální datum a čas.
 
+```yaml
 !NOW
 ```
 
 ---
 
-## `!DATETIME`: Zkonstruujte datum/čas 
+## `!DATETIME`: Konstrukce data/času
 
-Typ: _Mapování_.
+Typ: _Mapping_.
 
-Konstruuje `datový čas` ze složek, jako je rok, měsíc, den atd.
+Konstruuje `datetime` z komponent jako je rok, měsíc, den atd.
 
 ```yaml
 
+```yaml
 !DATETIME
-rok: <year>
-měsíc: <month>
-den: <day>
-hodina: <hour>
-minuta: <minute>
-hodina: sekunda: <second>
-mikrosekunda: <microsecond>
-časové pásmo: <timezone>
+year: <year>
+month: <month>
+day: <day>
+hour: <hour>
+minute: <minute>
+second: <second>
+microsecond: <microsecond>
+timezone: <timezone>
 ```
 
-8191: * `rok` je celé číslo v rozsahu -8190 ... 8191.
-* `měsíc` je celé číslo v rozsahu 1 ... 12.
+8191: * `year` je celé číslo v rozsahu -8190 ... 8191.
+* `month` je celé číslo v rozsahu 1 ... 12.
 * `day` je celé číslo v rozsahu 1 ... 31, odpovídající počtu dní v daném měsíci.
 * `hour` je celé číslo v rozsahu 0 ... 24, je nepovinné a výchozí hodnota je `0`.
-* `minuta` je celé číslo v rozsahu 0 ... 59, je nepovinné a výchozí hodnota je `0`.
-* `sekunda` je celé číslo v rozsahu 0 ... 60, je nepovinné a výchozí hodnota je `0`.
-* `mikrosekunda` je celé číslo v rozsahu 0 ... 1000000, je nepovinné a výchozí hodnota je `0`.
-* `timezone` je název [IANA Time Zone Database](https://www.iana.org/time-zones) časového pásma. Je nepovinný a výchozí časové pásmo je UTC.
+* `minute` je celé číslo v rozsahu 0 ... 59, je nepovinné a výchozí hodnota je `0`.
+* `second` je celé číslo v rozsahu 0 ... 60, je nepovinné a výchozí hodnota je `0`.
+* `microsecond` je celé číslo v rozsahu 0 ... 1000000, je nepovinné a výchozí hodnota je `0`.
+* `timezone` je název časového pásma podle [IANA Time Zone Database](https://www.iana.org/time-zones). Je nepovinný a výchozí časové pásmo je UTC.
 
 
 
-!!! example "Příklad: Datum/čas UTC"
+!!! example "Příklad: Datum/čas v UTC"
 
-	
-	
-	```yaml
-	!DATETIME
-	rok: 2021
-	měsíc: 10
-	den: 13
-	hodina: 12
-	minuta: 34
-	sekunda: 56
-	mikrosekunda: 987654
-	```
-	
-
-
-!!! example "Příklad: výchozí hodnoty"
-
-	
-	
-	```yaml
-	!DATETIME
-	year: 2021
-	měsíc: 10
-	den: 13
-	```
-	
-	
-
-
-!!! example "Příklad: časové pásmo"
-
-	
-	
 	```yaml
 	!DATETIME
 	year: 2021
 	month: 10
-	den: 13
-	časové pásmo: Evropa/Praha
+	day: 13
+	hour: 12
+	minute: 34
+	second: 56
+	microsecond: 987654
 	```
-	
+
+
+!!! example "Příklad: výchozí hodnoty"
+
 	```yaml
 	!DATETIME
-	rok: 2021
-	měsíc: 10
-	den: 13
-	časové pásmo: "+05:00"
+	year: 2021
+	month: 10
+	day: 13
 	```
-	
+
+
+!!! example "Příklad: časová pásma"
+
+	```yaml
+	!DATETIME
+	year: 2021
+	month: 10
+	day: 13
+	timezone: Europe/Prague
+	```
+
+	```yaml
+	!DATETIME
+	year: 2021
+	month: 10
+	day: 13
+	timezone: "+05:00"
+	```
 
 ---
 
 ## `!DATETIME.FORMAT`: Formátování data/času 
 
-Typ: _Mapování_.
+Typ: _Mapping_.
 
 Formátuje informace o datu a čase na základě `datetime`.
 
 ```yaml
 
 !DATETIME.FORMAT
-s: <datetime>
+with: <datetime>
 format: <format>
 timezone: <string>
 ```
 
 `datetime` obsahuje informace o datech a čase, které se mají použít pro formátování.
 `formát` je řetězec, který obsahuje specifikaci formátu výstupu.
-`Časové pásmo` je nepovinná informace, pokud je uvedena, bude čas vypsán v místním čase zadaném argumentem, jinak se použije časové pásmo UTC.
+`Časové pásmo` je nepovinná informace. Pokud je uvedena, bude čas vypsán v místním čase zadaném argumentem, jinak se použije časové pásmo UTC.
 
 ### Formát
 
-* `%H`: Hodiny (24hodinové hodiny) jako desetinné číslo doplněné nulou.
-* `%M`: Minuta jako desetinné číslo doplněné nulou.
-* `%S`: Vteřina jako desetinné číslo s nulovým znaménkem.
-* `%f`: Mikrosekunda jako desetinné číslo doplněné nulou na 6 číslic.
-* `%I`: Hodina (12hodinové hodiny) jako desetinné číslo doplněné nulou.
-* `%p`: Ekvivalent AM nebo PM v místním jazyce.
-
-* `%d`: Den v měsíci jako desetinné číslo s nulou.
-* `%m`: Měsíc jako desetinné číslo s nulou.
-* `%y`: Rok bez století jako desetinné číslo s nulou.
-* `%Y`: Rok se stoletím jako desetinné číslo.
-
-* `%z`: Posun UTC.
-
-* `%a`: Zkrácený název dne v týdnu.
-* `%A`: Den v týdnu jako plný název.
-* `%w`: Den v týdnu jako desetinné číslo, kde 0 je neděle a 6 je sobota.
-* `%b`: Měsíc jako zkrácený název.
-* `%B`: Měsíc jako plný název.
-* `%j`: Den v roce jako desetinné číslo s nulou.
-* `%U`: Číslo týdne v roce (neděle jako první den v týdnu) jako desetinné číslo s nulou. Všechny dny v novém roce předcházející první neděli se považují za dny v týdnu 0.
-* `%W`: Číslo týdne v roce (pondělí jako první den týdne) jako desetinné číslo s nulou. Všechny dny v novém roce předcházející prvnímu pondělí se považují za dny v týdnu 0.
-
-* `%c`: Zobrazení data a času.
-* `%x`: Reprezentace data.
-* `%X`: Reprezentace času.
-
-* `%%`: Doslovný znak '%'.
+| Direktiva | Komponenta |
+| --- | --- |
+|`%H`| Hodiny (24hodinové hodiny) jako desetinné číslo doplněné nulou. |
+|`%M`| Minuta jako desetinné číslo doplněné nulou. |
+|`%S`| Vteřina jako desetinné číslo s nulovým znaménkem. |
+|`%f`| Mikrosekunda jako desetinné číslo doplněné nulou na 6 číslic. |
+|`%I`| Hodina (12hodinové hodiny) jako desetinné číslo doplněné nulou. |
+|`%p`| Ekvivalent AM nebo PM v místním jazyce. |
+|`%d`| Den v měsíci jako desetinné číslo s nulou. |
+|`%m`| Měsíc jako desetinné číslo s nulou. |
+|`%y`| Rok bez století jako desetinné číslo s nulou. |
+|`%Y`| Rok se stoletím jako desetinné číslo. |
+|`%z`| Posun UTC. |
+|`%a`| Zkrácený název dne v týdnu. |
+|`%A`| Den v týdnu jako plný název. |
+|`%w`| Den v týdnu jako desetinné číslo, kde 0 je neděle a 6 je sobota. |
+|`%b`| Měsíc jako zkrácený název. |
+|`%B`| Měsíc jako plný název. |
+|`%j`| Den v roce jako desetinné číslo s nulou. |
+|`%U`| Číslo týdne v roce (neděle jako první den v týdnu) jako desetinné číslo s nulou.  Všechny dny v novém roce předcházející první neděli se považují za dny v týdnu 0. |
+|`%W`| Číslo týdne v roce (pondělí jako první den v týdnu) jako desetinné číslo s nulou. Všechny dny v novém roce předcházející prvnímu pondělí se považují za dny v týdnu 0. |
+|`%c`| Reprezentace data a času. |
+|`%x`| Reprezentace data. |
+|`%X`| Reprezentace času. |
+|`%%`| Doslovný znak '%'. |
 
 
-!!! example
+!!! example "Příklad"
 
-	
-	
 	```yaml
-	
 	!DATETIME.FORMAT
-	s: !NOW
+	with: !NOW
 	format: "%Y-%m-%d %H:%M:%S"
-	časové pásmo: "Europe/Prague"
+	timezone: "Europe/Prague"
 	```
 	
 	Vypíše aktuální místní čas jako např. `2022-12-31 12:34:56` s použitím časového pásma "Europe/Prague".
-	
-	
 
 ---
 
@@ -188,89 +168,75 @@ timezone: <string>
 
 Typ: _Mapping_.
 
-Parsování data a času z řetězce.
+Parsuje datum a čas z řetězce.
 
-```yaml
-
+```yaml 
 !DATETIME.PARSE
 what: <string>
 format: <format>
-časové pásmo: <timezone>
+timezone: <timezone>
 ```
 
 Vstupní řetězec `what` analyzuje pomocí řetězce `format`.
-Informace `timezone` je nepovinná, pokud je uvedena, pak určuje místní časové pásmo řetězce `what`.
+Informace `timezone` je nepovinná. Pokud je uvedena, určuje místní časové pásmo řetězce `what`.
 
-Další informace o řetězci `format` naleznete v kapitole "Formát" výše.
+Další informace o řetězci `format` naleznete v kapitole [Formát](#format) výše.
 
 
 
-!!! example
+!!! example  "Příklad"
 
-	
-	
 	```yaml
 	!DATETIME.PARSE
 	what: "2021-06-29T16:51:43-08"
 	format: "%y-%m-%dT%H:%M:%S%z"
 	```
-	
 
 ---
 
-## `!GET`: Získat komponentu datum/čas 
+## `!GET`: Získá komponentu datum/čas 
 
 Typ: _Mapping_.
 
-Výběr komponenty data/času, jako je hodina, minuta, den atd. z `datetime`.
+Extrahuje z `datetime` komponenty data/času, jako je hodina, minuta, den atd.
 
 ```yaml
-
 !GET
-co: <string>
-z: <datetime>
-časové pásmo: <timezone>
+what: <string>
+from: <datetime>
+timezone: <timezone>
 ```
 
-Výpis složky `what` z `datetime`.
-Časová zóna` je nepovinná, pokud není uvedena, použije se časová zóna UTC.
+Vybere komponentu `what` z `datetime`.
+`timezone` je nepovinná, pokud není uvedena, použije se časová zóna UTC.
 
 ### Komponenty
 
-* `year`, `y`: Year
-* `Měsíc`, `m`: Month
-* `day`, `d`: Day
+| Direktiva| Komponenta |
+| --- | --- |
+|`year`, `y`| Rok |
+| `month`, `m`| Měsíc |
+| `day`, `d`| Den |
+| `hour`, `H`| Hodina |
+| `minute`, `M`| Minuta |
+| `second`, `S`| Sekunda |
+| `microsecond`, `f`| Mikrosekunda |
+| `weekday`, `w`| Den v týdnu |
 
-* `hour`, `H`: Hodina
-* `minute`, `M`: minuta
-* `second`, `S`: Second
-* `mikrosekunda`, `f`: Microsecond
+!!! example  "Příklad"
 
-* `weekday`, `w`: Day of the week
-
-!!! example
-
-	
-	
 	```yaml
-	
 	!GET
-	co: H
-	od: !TEĎ
-	časové pásmo: "Europe/Prague"
+	what: H
+	from: !NOW
+	timezone: "Europe/Prague"
 	```
 	
-	Získá složku "hours" aktuálního časového razítka s použitím časového pásma "Europe/Prague".
-	
-	
+	Získá komponentu `hours` aktuálního časového razítka s použitím časového pásma "Europe/Prague".
 
 
-!!! example "Příklad: Získat aktuální rok"
+!!! example "Příklad: Aktuální rok"
 
-	
-	
 	```yaml
 	!GET { what: year, from: !NOW }
 	```
-	
-

--- a/cs/docs/expressions/dict.md
+++ b/cs/docs/expressions/dict.md
@@ -1,6 +1,6 @@
 ---
 git_commit_hash: b55fa3f
-title: Slovník
+title: Slovníky
 ---
 
 # Slovníkový výraz

--- a/cs/docs/expressions/dict.md
+++ b/cs/docs/expressions/dict.md
@@ -3,167 +3,152 @@ git_commit_hash: b55fa3f
 title: Slovníky
 ---
 
-# Slovníkový výraz
+# Slovníkové výrazy
 
-
-Dict (neboli slovník) uchovává kolekci dvojic (klíč, hodnota) tak, že každý možný klíč se v kolekci vyskytuje nejvýše jednou.
+**Slovník (dict)** uchovává kolekci dvojic (klíč, hodnota) tak, že každý možný klíč se v kolekci vyskytuje nejvýše jednou.
 Klíče ve slovníku musí být stejného typu, stejně jako hodnoty.
-Množina je jednou ze základních datových struktur poskytovaných jazykem SP-Lang.
 
 Položka je dvojice (klíč, hodnota) reprezentovaná jako tuple.
 
-Tip: Tuto strukturu můžete znát pod alternativními názvy "asociativní pole" nebo "mapa".
+!!! Hint "Nápověda"
+
+	Tuto strukturu můžete znát pod alternativními názvy "asociativní pole" nebo "mapa".
 
 --- 
 
 ## `!DICT`: Dictionary 
 
 Typ:  _Mapping_
-```yaml
 
+```yaml
 !DICT
-s:
- <key1>: <value1>
+with:
+  <key1>: <value1>
   <key2>: <value2>
   <key3>: <value3>
   ...
 ```
 
-!!! hint
+!!! hint "Nápověda"
 
-	
-	
-	
-	Pro zjištění počtu položek ve slovníku použijte `!COUNT`.
-	
-	
+	Pro zjištění počtu položek ve slovníku použijte [`!COUNT`](../aggregate/#count-pocet-polozek).
 
-!!! example
 
-	
-	
-	
+!!! example "Příklad"
+
 	V jazyce SP-Lang lze slovník zadat několika způsoby:
+
 	```yaml
-	
 	!DICT
-	s:
-	  klíč1: "One"
+	with:
+	  key1: "One"
 	  key2: "Two"
 	  key3: "Three"
 	```
 	
-	Implicitní slovník:
+	Implicitně zadaný slovník:
+
 	```yaml
-	
 	---
 	key1: "One"
 	key2: "Two"
 	key3: "Three"
+	```"Three"
 	```
 	
-	Konzistentní slovník používající `!!dict` a styl toku YAML:
+	Slovník zadaný zkráceně využívaje `!!dict` a flow stylu v YAML:
+
 	```yaml
-	
-	!!dict {key1: "Jedna", key2: "Dvě", key3: "Tři"}
+	!!dict {key1: "One", key2: "Two", key3: "Three"}
 	```
 	
 
 ### Specifikace typu
 
 Typ slovníku se označuje jako `{Tk:Tv}`, kde `Tk` je typ klíče a `Tv` je typ hodnoty.
-Další informace o typu slovníku naleznete v příslušné kapitole v [typovém systému](../jazyk/typy#slovníku).
+Další informace o typu slovníku naleznete v příslušné kapitole v [typovém systému](../../language/types/#slovnik).
 
 Slovník se pokusí odvodit svůj typ na základě přidaných položek.
 Typ první položky pravděpodobně poskytne typ klíče `Tk` a typ hodnoty `Tv`.
 Pokud je slovník prázdný, jeho odvozený typ je `{str:si64}`.
 
-Toto můžete přepsat pomocí explicitní specifikace typu:
-```yaml
+Toto lze přepsat pomocí explicitní specifikace typu:
 
+```yaml
 !DICT
-typ: "{str:any}"
+type: "{str:any}"
 with:
- <key1>: <value1>
+  <key1>: <value1>
   <key2>: <value2>
   <key3>: <value3>
   ...
 ```
 
-`type` je nepovinný argument obsahující řetězec se signaturou slovníku.
-Tato signatura bude použita pro tuto signaturu namísto odvození typu z childs.
+`type` je nepovinný argument obsahující řetězec se signaturou slovníku, která bude použita namísto odvozování typu z následníků.
 
 Ve výše uvedeném příkladu je typ slovníku `{str:any}`, typ klíče je `str` a typ hodnot je `any`.
 
 
 --- 
 
-## `!GET`: Získat hodnotu ze slovníku 
+## `!GET`: Získá hodnotu ze slovníku 
 
 Typ: _Mapping_.
 
 ```yaml
-
 !GET
-co: <key>
-z: <dict>
-výchozí: <value>
+what: <key>
+from: <dict>
+default: <value>
 ```
 
-Získat položku ze slovníku `dict` (slovník) identifikovaného pomocí `key`.
+Získá hodnotu ze slovníku `dict` (slovník) identifikovaného pomocí `key`.
 
 Pokud `klíč` není nalezen, vrátí `default` nebo chybu, pokud `default` není zadán.
 `default` je nepovinné.
 
+!!! example "Příklad"
 
-!!! example
-
-	
-	
 	```yaml
-	
 	!GET
-	co: 3
-	od:
+	what: 3
+	from:
 	  !DICT
-	  s:
-	    1: "One"
-	    2: "Two"
-	    3: "Three"
+	  with:
+		1: "One"
+		2: "Two"
+		3: "Three"
 	```
-	
-	Vrací `Three`.
-	
+
+	Returns `Three`.
 
 --- 
 
-## `!IN`: Test členství 
+## `!IN`: Test výskytu
 
 Typ: _Mapping_.
-```yaml
 
+```yaml
 !IN
-co: <key>
-kde: <dict>
+what: <key>
+where: <dict>
 ```
 
-Zkontrolujte, zda je `key` přítomen v `dict`.
+Zkontroluje, zda je `key` přítomen v `dict`.
 
-Poznámka: Výraz `!IN` je popsán v kapitole "Testy".
+!!! note "Poznámka"
 
+	Výraz `!IN` je popsán v kapitole [Porovnávací výrazy](../comparisons/#in-test-vyskytu).
 
-!!! example
+!!! example "Příklad"
 
-	
-	
 	```yaml
 	!IN
-	co: 3
-	kde:
+	what: 3
+	where:
 	  !DICT
-	  s:
-	    1: "One"
-	    2: "Two"
-	    3: "Three"
+	  with:
+		1: "One"
+		2: "Two"
+		3: "Three"
 	```
-

--- a/cs/docs/expressions/directives.md
+++ b/cs/docs/expressions/directives.md
@@ -3,14 +3,10 @@ git_commit_hash: b55fa3f
 title: Direktivy
 ---
 
-# Směrnice
-
+# Direktivy
 
 !!! note
 
-	
-	
-	
 	Směrnice SP-Lang jsou při kompilaci rozšířeny. Nejsou to výrazy.
 	
 

--- a/cs/docs/expressions/directives.md
+++ b/cs/docs/expressions/directives.md
@@ -7,49 +7,48 @@ title: Direktivy
 
 !!! note
 
-	Směrnice SP-Lang jsou při kompilaci rozšířeny. Nejsou to výrazy.
-	
+    Direktivy SP-Lang jsou při kompilaci rozšířeny. Nejsou to výrazy.
+
 
 --- 
 
-## `!INCLUDE`: Vložte obsah jiného souboru 
+## `!INCLUDE`: Vloží obsah jiného souboru
 
-Typ: Typ: Skalární, Směrnice.
+Typ: Skalární, Direktiva.
 
 Direktiva `!INCLUDE` slouží k vložení obsahu daného souboru do aktuálního souboru.
-Pokud není includovaný soubor nalezen, SP-Lang zobrazí chybu.
+Pokud není vkládaný soubor nalezen, SP-Lang zobrazí chybu.
 
 
-### Synopse
+### Synopsis
+
 ```yaml
-
 !INCLUDE <filename>
 ```
 
-`Jméno souboru` je název souboru v knihovně, který má být zahrnut.
+`filename` je název souboru v knihovně, který má být vložen.
 
-Může to být:
+Můžeme ho specifikovat pomocí:
 
-* absolutní cesta začínající na `/` z kořene knihovny,
-* relativní cesta k umístění souboru obsahujícího příkaz `!INCLUDE`
+* absolutní cesty začínající na `/` z kořene knihovny,
+* relativní cesty k umístění souboru obsahujícího příkaz `!INCLUDE`
   
 Přípona `.yaml` je nepovinná a bude přidána ke jménu souboru, pokud chybí.
 
-### Příklad
-```yaml
+!!! example "Příklad"
 
-!INCLUDE other_file.yaml
-```
+	```yaml
+	!INCLUDE other_file.yaml
+	```
 
-Jedná se o jednoduché začlenění souboru `other_file.yaml`.
-  
-```yaml
+	Jedná se o jednoduché začlenění souboru `other_file.yaml`.
 
-!MATCH
-what: !GET {...}
-with:
-  'group1': !INCLUDE inc_group1
-  'group2': !INCLUDE inc_group2
-```
+	```yaml
+	!MATCH
+	what: !GET {...}
+	with:
+	'group1': !INCLUDE inc_group1
+	'group2': !INCLUDE inc_group2
+	```
 
-V tomto příkladu se `!INCLUDE` používá k rozkladu většího výrazu na logicky oddělené soubory.
+	V tomto příkladu se `!INCLUDE` používá k rozkladu většího výrazu na logicky oddělené soubory.

--- a/cs/docs/expressions/directives.md
+++ b/cs/docs/expressions/directives.md
@@ -1,6 +1,6 @@
 ---
 git_commit_hash: b55fa3f
-title: Směrnice
+title: Direktivy
 ---
 
 # Směrnice

--- a/cs/docs/expressions/directives.md
+++ b/cs/docs/expressions/directives.md
@@ -20,7 +20,7 @@ Direktiva `!INCLUDE` slouží k vložení obsahu daného souboru do aktuálního
 Pokud není vkládaný soubor nalezen, SP-Lang zobrazí chybu.
 
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !INCLUDE <filename>

--- a/cs/docs/expressions/function.md
+++ b/cs/docs/expressions/function.md
@@ -11,7 +11,7 @@ title: Funkce
 
 Typ: _Scalar_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !ARGUMENT name
@@ -43,7 +43,7 @@ Typ: _Mapping_.
 	Výrazy SP-Lang jsou _implicitně_ umístěné definice funkcí.
 	To znamená, že ve většině případů lze `!FUNCTION` přeskočit a je uvedena pouze sekce `do`.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !FUNCTION
@@ -92,7 +92,7 @@ Příkaz `!SELF` umožňuje rekurzivně použít "self" alias aktuální funkci.
 
 Typ: _Mapping_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !SELF

--- a/cs/docs/expressions/function.md
+++ b/cs/docs/expressions/function.md
@@ -3,23 +3,21 @@ git_commit_hash: b55fa3f
 title: Funkce
 ---
 
-# Výrazy funkcí
-
-
+# Výrazy pro funkce
 
 --- 
 
-## `!ARGUMENT`, `!ARG`: Získat argument funkce  
+## `!ARGUMENT`, `!ARG`: Získá argument funkce  
 
 Typ: _Scalar_.
 
-### Synopse
-```yaml
+### Synopsis
 
+```yaml
 !ARGUMENT name
 ```
-```yaml
 
+```yaml
 !ARG name
 ```
 
@@ -27,12 +25,7 @@ Umožňuje přístup k argumentu `name`.
 
 !!! tip
 
-	
-	
-	
-	`!ARG` je stručnou verzí `!ARGUMENT`.
-	
-	
+	`!ARG` je zkrácená verze `!ARGUMENT`.
 
 --- 
 
@@ -40,107 +33,94 @@ Umožňuje přístup k argumentu `name`.
 
 
 Výraz `!FUNCTION` definuje novou funkci.
-Obvykle se používá jako výraz nejvyšší úrovně.
+Obvykle se používá jako top-level expression.
 
-Typ: _Mapování_.
+Typ: _Mapping_.
 
 
 !!! info
 
-	
-	
-	
 	Výrazy SP-Lang jsou _implicitně_ umístěné definice funkcí.
 	To znamená, že ve většině případů lze `!FUNCTION` přeskočit a je uvedena pouze sekce `do`.
-	
-	
 
-### Synopse
+### Synopsis
+
 ```yaml
-
 !FUNCTION
 name: <name of function>
-argumenty:
-  argument1: <type>
+arguments:
+  arg1: <type>
   arg2: <type>
   ...
-vrací: <type>
-schémata: Argumenty: Argumenty: Argumenty: Argumenty: Argumenty: arg: <dictionary of schemas>
+returns: <type>
+schemas: <dictionary of schemas>
 do:
- <expression>
+  <expression>
 ```
 
 !!! tip
 
-	
-	
-	
 	`!FN` je zkrácená verze `!FUNCTION`.
-	
-	
 
-### Příklad
-```yaml
 
-!FUNCTION
-argumenty:
-  a: si64
-  b: si32
-  c: si32
-  d: si32
-vrací: fp64
-do:
-  !MUL
-  - !ARGUMENT a
-  - !ARGUMENT b
-  - !ARGUMENT c
-  - !ARGUMENT d
-```
+!!! example "Příklad"
 
-Tento výraz definuje funkci, která přijímá čtyři argumenty (`a`, `b`, `c` a `d`) s příslušnými datovými typy (`si64`, `si32`, `si32` a `si32`) a vrací výsledek typu `fp64`.
-Funkce vynásobí čtyři vstupní argumenty (`a`, `b`, `c` a `d`) a vrátí součin jako číslo s pohyblivou řádovou čárkou (`fp64`).
+	```yaml
+	!FUNCTION
+	arguments:
+	a: si64
+	b: si32
+	c: si32
+	d: si32
+	returns: fp64
+	do:
+	!MUL
+	- !ARGUMENT a
+	- !ARGUMENT b
+	- !ARGUMENT c
+	- !ARGUMENT d
+	```
+
+	Tento výraz definuje funkci, která přijímá čtyři argumenty (`a`, `b`, `c` a `d`) s příslušnými datovými typy (`si64`, `si32`, `si32` a `si32`) a vrací výsledek typu `fp64`.
+	Funkce vynásobí čtyři vstupní argumenty (`a`, `b`, `c` a `d`) a vrátí součin jako číslo s desetinou čárkou (`fp64`).
 
 --- 
 
-## `!SELF`: Použijte aktuální funkci  
+## `!SELF`: Použije aktuální funkci  
 
 Příkaz `!SELF` umožňuje rekurzivně použít "self" alias aktuální funkci.
 
-Typ: _Mapování_.
+Typ: _Mapping_.
 
-### Synopse
+### Synopsis
+
 ```yaml
-
 !SELF
 arg1: <value>
 arg2: <value>
 ...
 ```
 
-!!! note
+!!! note "Poznámka"
 
-	
-	
-	
-	Výraz `!SELF` je kombinátor [Y](https://en.wikipedia.org/wiki/Fixed-point_combinator#Y_combinator).
-	
-	
+	Výraz `!SELF` je tzv. [Y kombinátor](https://en.wikipedia.org/wiki/Fixed-point_combinator#Y_combinator).
 
-### Příklad
 
-```yaml
+!!! example "Příklad"
 
-!FUNCTION
-argumenty: {x: int}
-vrací: int
-do:
-  !IF # hodnota &lt;= 1
-  test: !GT [!ARG x, 1]
-  potom: !MUL [!SELF {x: !SUB [!ARG x, 1]}, !ARG x]
-  else: 1
-```
+	```yaml
 
-Tento výraz definuje rekurzivní funkci, která přijímá jeden celočíselný argument `x` a vrací celočíselný výsledek.
-Funkce vypočítá faktoriál vstupního argumentu `x` pomocí příkazu if-else.
-Pokud je vstupní hodnota `x` větší než 1, funkce vynásobí `x` faktoriálem (`x` - 1), který vypočítá rekurzivním voláním sebe sama.
-Pokud je vstupní hodnota `x` menší nebo rovna 1, funkce vrátí 1.
+	!FUNCTION
+	argumenty: {x: int}
+	vrací: int
+	do:
+	!IF # hodnota &lt;= 1
+	test: !GT [!ARG x, 1]
+	potom: !MUL [!SELF {x: !SUB [!ARG x, 1]}, !ARG x]
+	else: 1
+	```
+
+	Tento výraz definuje rekurzivní funkci, která přijímá jeden celočíselný argument `x` a vrací celočíselný výsledek.
+	Funkce vypočítá faktoriál vstupního argumentu `x` pomocí příkazu if-else.
+	Pokud je vstupní hodnota `x` větší než 1, funkce vynásobí `x` faktoriálem (`x` - 1), který vypočítá rekurzivním voláním sebe sama.
+	Pokud je vstupní hodnota `x` menší nebo rovna 1, funkce vrátí 1.

--- a/cs/docs/expressions/ip.md
+++ b/cs/docs/expressions/ip.md
@@ -32,7 +32,7 @@ Převádí vnitřní reprezentaci IP adresy na řetězec.
 
 Typ: _Mapping_.
 
-### Synopse
+### Synopsis
 
 ```yaml
 !IP.INSUBNET

--- a/cs/docs/expressions/ip.md
+++ b/cs/docs/expressions/ip.md
@@ -3,107 +3,106 @@ git_commit_hash: b55fa3f
 title: IP adresy
 ---
 
-# Vyjádření IP adresy
+# Výrazy pro IP adresy
 
 
-IP adresy jsou interně reprezentovány jako číslo, 128bitové celé číslo bez znaménka.
+IP adresy jsou interně reprezentovány jako 128bitová celá čísla bez znaménka.
 Takový typ může obsahovat jak IPv6, tak IPv4.
 IPv4 jsou mapovány do prostoru IPv6 pomocí [RFC 4291 "IPv4-Mapped IPv6 Address"](https://datatracker.ietf.org/doc/html/rfc4291#section-2.5.5.2).
 
 --- 
 
-## `!IP.FORMAT`: Převést IP adresu na řetězec  
+## `!IP.FORMAT`: Převádí IP adresu na řetězec  
 
-Typ: _Mapování_.
+Typ: _Mapping_.
 
-### Synopse
+### Synopsis
+
 ```yaml
-
 !IP.FORMAT
-co: <ip>
+what: <ip>
 ```
 
-Převést vnitřní reprezentaci IP adresy na řetězec.
+Převádí vnitřní reprezentaci IP adresy na řetězec.
 
 
 --- 
 
-## `!IP.INSUBNET`: Zkontrolujte, zda IP adresa spadá do podsítě 
+## `!IP.INSUBNET`: Zkontroluje, zda IP adresa spadá do podsítě 
 
 Typ: _Mapping_.
 
 ### Synopse
-```yaml
 
+```yaml
 !IP.INSUBNET
-co: <ip>
+what: <ip>
 subnet: <subnet>
 ```
-```yaml
 
+```yaml
 !IP.INSUBNET
-co: <ip>
+what: <ip>
 subnet:
   - <string>
   - <string>
   - <string>
 ```
 
-Testuje, zda `jaká` IP adresa patří do `podsítě` nebo podsítí , vrací `pravdu`, pokud ano, jinak `nepravdu`.
+Testuje, zda `what` IP adresa patří do `subnet` nebo podsítí, vrací `true`, pokud ano, jinak `false`.
 
-### Příklad s jednou podsítí
-```yaml
+!!! example "Příklad s jednou podsítí"
 
-!IP.INSUBNET
-co: 192.168.1.1
-podsíť: 192.168.0.0/16
-```
-
-
-### Příklad s více podsítěmi
-```yaml
-
-!IP.INSUBNET
-co: 1.2.3.4
-podsíť:
-  - 10.0.0.0/8
-  - 172.16.0.0/12
-  - 192.168.0.0/16
-```
-
-Test, který kontroluje, zda adresa IP pochází z privátního adresního prostoru IPv4, jak je definováno v [RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918).
+	```yaml
+	!IP.INSUBNET
+	what: 192.168.1.1
+	subnet: 192.168.0.0/16
+	```
 
 
-Kompaktnější podoba:
-```yaml
+!!! example "Příklad s více podsítěmi"
 
-!IP.INSUBNET
-co: 1.2.3.4
-podsíť: [10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16]
-```
+	```yaml
+	!IP.INSUBNET
+	what: 1.2.3.4
+	subnet:
+	- 10.0.0.0/8
+	- 172.16.0.0/12
+	- 192.168.0.0/16
+	```
+
+	Test, který kontroluje, zda adresa IP pochází z privátního adresního prostoru IPv4, jak je definováno v [RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918).
+
+	Kompaktní forma:
+
+	```yaml
+	!IP.INSUBNET
+	what: 1.2.3.4
+	subnet: [10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16]
+	```
 
 
 ---
 
-## Rozbor IP adresy
+## Parsování IP adresy
 
 IP adresa je automaticky analyzována z řetězce.
 V případě potřeby můžete IP adresu z řetězce explicitně převést na typ `ip`:
-```yaml
 
+```yaml
 !CAST
-typ: ip
-co: 192.168.1.1
+type: ip
+what: 192.168.1.1
 ```
 
 
-## Rozbor podsítě IP
+## Parsování podsítě IP
 
-IP podsíť je automaticky analyzována z řetězce.
-V případě potřeby můžete explicitně převést IP adresu z řetězce na typ `ipsubnet`:
+IP podsíť je automaticky parsována z řetězce.
+V případě potřeby lze explicitně převést IP adresu z řetězce na typ `ipsubnet`:
+
 ```yaml
-
 !CAST
-typ: ipsubnet
-co: 192.168.1.1/16
+type: ipsubnet
+what: 192.168.1.1/16
 ```

--- a/cs/docs/expressions/ip.md
+++ b/cs/docs/expressions/ip.md
@@ -1,6 +1,6 @@
 ---
 git_commit_hash: b55fa3f
-title: IP adresa
+title: IP adresy
 ---
 
 # Vyjádření IP adresy

--- a/cs/docs/expressions/ip.md
+++ b/cs/docs/expressions/ip.md
@@ -16,7 +16,7 @@ IPv4 jsou mapovány do prostoru IPv6 pomocí [RFC 4291 "IPv4-Mapped IPv6 Address
 
 Typ: _Mapping_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !IP.FORMAT
@@ -32,7 +32,7 @@ Převádí vnitřní reprezentaci IP adresy na řetězec.
 
 Typ: _Mapping_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !IP.INSUBNET

--- a/cs/docs/expressions/json.md
+++ b/cs/docs/expressions/json.md
@@ -20,7 +20,7 @@ Typ: _Mapping_.
 ```yaml
 
 !GET
-co: <item>
+what: <item>
 typ: <type>
 od: <json>
 výchozí: <value>

--- a/cs/docs/expressions/json.md
+++ b/cs/docs/expressions/json.md
@@ -15,7 +15,7 @@ SP-Lang nabízí [vysokorychlostní přístup](https://simdjson.org) k datovým 
 Typ: _Mapping_.
 
 
-### Synopsis
+Synopsis:
 
 ```yaml
 
@@ -85,7 +85,7 @@ Pro odvození typu položky se použije schéma, ale pro složitější přístu
 
 Typ: _Mapping_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 

--- a/cs/docs/expressions/json.md
+++ b/cs/docs/expressions/json.md
@@ -10,12 +10,13 @@ SP-Lang nabízí [vysokorychlostní přístup](https://simdjson.org) k datovým 
 
 --- 
 
-## `!GET`: Získat hodnotu z JSON 
+## `!GET`: Získá hodnotu z JSON 
 
 Typ: _Mapping_.
 
 
-### Synopse
+### Synopsis
+
 ```yaml
 
 !GET
@@ -31,57 +32,61 @@ Pokud položka není nalezena, vrátí `default` nebo chybu, pokud není zadáno
 
 Volitelně můžete zadat typ položky pomocí `type`.
 
-### Příklad
+!!! example "Příklad"
 
-JSON (také známý jako `!ARG jsonmessage`):
-```json
+	JSON (`!ARG jsonmessage`):
 
-{
-  "foo.bar": "Příklad"
-}
-```
+	```json
+	{
+	"foo.bar": "Příklad"
+	}
+	```
 
-Získání pole `foo.bar` z výše uvedeného JSON:
-```yaml
+	Pro získání pole `foo.bar` z výše uvedeného JSON:
 
-!GET
-co: foo.bar
-from: !ARG jsonmessage
-```
+	```yaml
+
+	!GET
+	what: foo.bar
+	from: !ARG jsonmessage
+	```
 
 
 ### JSON Pointer
 
-Pokud chcete přistupovat k položce ve vnořeném JSON, musíte použít [JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901) (např. `/foo/bar` o`/foo/bar`) jako `what` pro tento účel.
+Pro přístup k položce ve vnořeném JSONu je třeba použít [JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901) (např. `/foo/bar` o`/foo/bar`) jako `what`.
 
-Pro odvození typu položky se použije schéma, ale pro složitější přístup se doporučuje použít argument `type`.
+Pro odvození typu položky se použije schéma, ale pro složitější přístup doporučujeme použít argument `type`.
 
-Vnořený JSON (aka `!ARG jsonmessage`):
-```json
+!!! example "Příklad"
 
-{
-  "foo": {
-    "bar": "Příklad"
-  }
-}
-```
+	Vnořený JSON (`!ARG jsonmessage`):
 
-Příklad extrakce řetězce z vnořeného JSON:
-```yaml
+	```json
+	{
+	"foo": {
+		"bar": "Příklad"
+	}
+	}
+	```
 
-!GET
-co: /foo/bar
-typ: str
-from: !ARG jsonmessage
-```
+	Příklad extrakce řetězce z vnořeného JSON:
+
+	```yaml
+	!GET
+	what: /foo/bar
+	type: str
+	from: !ARG jsonmessage
+	```
 
 --- 
 
-## `!JSON.PARSE`: Parse JSON 
+## `!JSON.PARSE`: Parsuje JSON 
 
 Typ: _Mapping_.
 
-### Synopse
+### Synopsis
+
 ```yaml
 
 !JSON.PARSE
@@ -89,20 +94,21 @@ what: <str>
 schéma: <schema>
 ```
 
-Parsovat JSON řetězec.
+Parsuje JSON řetězec.
 Výsledek lze použít např. pomocí operátoru `!GET`.
 
 Nepovinný argument `schema` určuje schéma, které se má použít.
 Výchozím schématem je vestavěné schéma `ANY`.
 
 
-### Příklad
-```yaml
+!!! example "Příklad"
 
-!JSON.PARSE
-what: |
-  {
-    "string1": "Hello World!",
-    "string2": "Goodbay ..."
-  }
-```
+	```yaml
+
+	!JSON.PARSE
+	what: |
+	{
+		"string1": "Hello World!",
+		"string2": "Goodby ..."
+	}
+	```

--- a/cs/docs/expressions/list.md
+++ b/cs/docs/expressions/list.md
@@ -1,6 +1,6 @@
 ---
 git_commit_hash: b55fa3f
-title: Seznam
+title: Seznamy
 ---
 
 # Seznam výrazů

--- a/cs/docs/expressions/list.md
+++ b/cs/docs/expressions/list.md
@@ -21,7 +21,7 @@ Položky v seznamu musí být stejného typu.
 
 Typ:  _Implicit sequence_, _Mapping_.
 
-### Synopse
+### Synopsis
 
 ```yaml
 
@@ -76,7 +76,7 @@ Existuje několik způsobů, jak lze v jazyce SP-Lang zadat seznam:
 
 	```yaml
 	!LIST
-	s:
+	with:
 	- "One"
 	- "Two"
 	- "Three"
@@ -96,7 +96,7 @@ Typ: _Mapping_.
 ```yaml
 
 !GET
-co: <index of the item in the list>
+what: <index of the item in the list>
 z: <list>
 ```
 

--- a/cs/docs/expressions/list.md
+++ b/cs/docs/expressions/list.md
@@ -21,7 +21,7 @@ Položky v seznamu musí být stejného typu.
 
 Typ:  _Implicit sequence_, _Mapping_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 
@@ -91,7 +91,7 @@ Existuje několik způsobů, jak lze v jazyce SP-Lang zadat seznam:
 Typ: _Mapping_.
 
 
-### Synopsis
+Synopsis:
 
 ```yaml
 

--- a/cs/docs/expressions/list.md
+++ b/cs/docs/expressions/list.md
@@ -3,91 +3,96 @@ git_commit_hash: b55fa3f
 title: Seznamy
 ---
 
-# Seznam výrazů
+# Výraz pro seznamy
 
 
-Seznam je jednou ze základních datových struktur, které SP-Lang nabízí.
+Seznam (list) je jednou ze základních datových struktur, které SP-Lang nabízí.
 Seznam obsahuje konečný počet uspořádaných položek, přičemž stejná položka se může vyskytovat vícekrát.
 Položky v seznamu musí být stejného typu.
 
-!!! note
+!!! note "Poznámka"
 
-	
-	
-	
 	Seznam se někdy nepřesně nazývá také _pole_.
-	
-	
+
 
 --- 
 
 ## `!LIST`: Seznam položek 
 
-Typ:  _Implicitní posloupnost_, _Mapování_.
+Typ:  _Implicit sequence_, _Mapping_.
 
 ### Synopse
+
 ```yaml
 
 !LIST
 - ...
 - ...
 ```
+!!! hint "Nápověda"
 
-_Nápověda: Pro určení počtu položek v seznamu použijte `!COUNT`._
+	Pro určení počtu položek v seznamu použijte `!COUNT`.
 
 
 ### Příklady
 
 Existuje několik způsobů, jak lze v jazyce SP-Lang zadat seznam:
-```yaml
 
-!LIST
-- "One"
-- "Dva"
-- "Three"
-- "Four"
-- "Five"
-```
+!!! example
+	```yaml
 
+	!LIST
+	- "One"
+	- "Two"
+	- "Three"
+	- "Four"
+	- "Five"
+	```
 
-Implicitní seznam pomocí [sekvencí bloků YAML](https://yaml.org/spec/1.2.2/#821-block-sequences):
-```yaml
+!!! example
 
-- "One"
-- "Dva"
-- "Tři"
-- "Čtyři"
-- "Pět"
-```
+	Implicitní seznam pomocí [sekvencí bloků YAML](https://yaml.org/spec/1.2.2/#821-block-sequences):
 
+	```yaml
+	- "One"
+	- "Two"
+	- "Three"
+	- "Four"
+	- "Five"
+	```
 
-Implicitní seznam pomocí [YAML flow sequences](https://yaml.org/spec/1.2.2/#741-flow-sequences):
-```yaml
+!!! example
 
-["Jedna", "Dvě", "Tři", "Čtyři", "Pět"]
-```
+	Implicitní seznam pomocí [YAML flow sequences](https://yaml.org/spec/1.2.2/#741-flow-sequences):
 
+	```yaml
 
-Formulář mapování:
-```yaml
+	["One", "Dvě", "Three", "Four", "Five"]
+	```
 
-!LIST
-s:
-  - "One"
-  - "Two"
-  - "Three"
-  - "Four"
-  - "Pět"
-```
+!!! example
+
+	Formou mapování:
+
+	```yaml
+	!LIST
+	s:
+	- "One"
+	- "Two"
+	- "Three"
+	- "Four"
+	- "Five"
+	```
 
 --- 
 
-## `!GET`: Získat položku ze seznamu 
+## `!GET`: Získá položku ze seznamu 
 
 Typ: _Mapping_.
 
 
-### Synopse
+### Synopsis
+
 ```yaml
 
 !GET
@@ -103,36 +108,39 @@ Položky jsou indexovány od 0, to znamená, že první položka v seznamu má i
 Pokud je `index` mimo hranice seznamu, příkaz se vrátí s chybou.
 
 
-### Příklady
-```yaml
+!!! example "Příklad"
 
-!GET
-co: 3
-from:
-  !LIST
-  - 1
-  - 5
-  - 30
-  - 50
-  - 80
-  - 120
-```
+	```yaml
 
-Vrací hodnotu `50`.
+	!GET
+	what: 3
+	from:
+	!LIST
+	- 1
+	- 5
+	- 30
+	- 50
+	- 80
+	- 120
+	```
 
-```yaml
+	Vrací hodnotu `50`.
 
-!GET
-what: -1
-od:
-  !LIST
-  - 1
-  - 5
-  - 30
-  - 50
-  - 80
-  - 120
-```
+!!! example "Příklad"
 
-Vrátí poslední položku seznamu, která je `120`.
+	```yaml
+
+	!GET
+	what: -1
+	od:
+	!LIST
+	- 1
+	- 5
+	- 30
+	- 50
+	- 80
+	- 120
+	```
+
+	Vrací poslední položku seznamu, která je `120`.
 

--- a/cs/docs/expressions/logic.md
+++ b/cs/docs/expressions/logic.md
@@ -11,8 +11,6 @@ Logické výrazy pracují s pravdivostními hodnotami `true` a `false`.
 
 !!! info "Logické výrazy jsou reprezentací logické algebry"
 
-	
-	
 	Další informace naleznete na stránce [boolean algebra](https://en.wikipedia.org/wiki/Boolean_algebra) na Wikipedii.
 	
 	
@@ -24,11 +22,11 @@ Logické výrazy pracují s pravdivostními hodnotami `true` a `false`.
 Logický výraz `!AND` se používá ke spojení dvou nebo více podmínek, které musí být všechny pravdivé, aby byl celý výraz pravdivý.
 Používá se k vytváření přísnějších a přesnějších podmínek.
 
-Typ: _Posloupnost_
+Typ: _Sequence_
 
-### Synopse
+### Synopsis
 
-```
+```yaml
 !AND
 - <condition 1>
 - <condition 2>
@@ -41,135 +39,132 @@ Podmínky jsou vyhodnocovány shora dolů a proces vyhodnocování se zastaví, 
 
 !!! info "Logická konjunkce"
 
-	
-	
 	Další informace naleznete na stránce [Logická konjunkce](https://en.wikipedia.org/wiki/Logical_conjunction) na Wikipedii.
 	
 	
 
-### Příklad
-```yaml
+!!! example "Příklad"
 
-!AND
-- !EQ
-  - !ARG prodejce
-  - TeskaLabs
-- !EQ
-  - !ARG produkt
-  - LogMan.io
-- !EQ
-  - !ARG verze
-  - v23.10
-```
+	```yaml
 
-V tomto příkladu, pokud se všechny podmínky vyhodnotí jako pravdivé, bude celý logický výraz `!AND` pravdivý.
-Pokud je některá z podmínek nepravdivá, bude logický výraz `!AND` nepravdivý.
+	!AND
+	- !EQ
+	- !ARG prodejce
+	- TeskaLabs
+	- !EQ
+	- !ARG produkt
+	- LogMan.io
+	- !EQ
+	- !ARG verze
+	- v23.10
+	```
+
+	V tomto příkladu, pokud se všechny podmínky vyhodnotí jako pravdivé, bude celý logický výraz `!AND` pravdivý.
+	Pokud je některá z podmínek nepravdivá, bude logický výraz `!AND` nepravdivý.
 
 
 ### Bitové `!AND`
 
 Pokud se `!AND` použije na celočíselné typy místo na logické, vytvoří se bitové AND.
 
-### Příklad
-```yaml
+!!! example "Příklad"
 
-!AND
-- !ARG PRI
-- 7
-```
+	```yaml
+	!AND
+	- !ARG PRI
+	- 7
+	```
 
-V tomto příkladu je argument `PRI` maskován číslem 7 (binárně `00000111`).
+	V tomto příkladu je argument `PRI` maskován číslem 7 (binárně `00000111`).
 
 ---
 
-## `!OR`: . 
+## `!OR`: Disjunkce
 
 Logický výraz `!OR` se používá ke spojení dvou nebo více podmínek, přičemž alespoň jedna z podmínek musí být pravdivá, aby byl celý výraz pravdivý.
 Používá se k vytváření flexibilnějších a komplexnějších podmínek.
 
-Typ: _Posloupnost_
+Typ: _Sequence_
 
-### Synopse
+### Synopsis
 
-```
+```yaml
 !OR
 - <condition 1>
 - <condition 2>
 - ...
 ```
 
-Podmínky (`podmínka 1`, `podmínka 2`, ...) mohou být libovolné výrazy, které se vyhodnotí jako logická hodnota (`pravda` nebo `nepravda`).
+Podmínky (`condition 1`, `condition 2`, ...) mohou být libovolné výrazy, které se vyhodnotí jako logická hodnota (`true` nebo `false`).
 Podmínky jsou vyhodnocovány shora dolů a proces vyhodnocování se zastaví, jakmile je nalezena pravdivá podmínka, podle konceptu zkráceného vyhodnocování.
 
 
 !!! info "Logická disjunkce"
 
-	
-	
-	Další informace naleznete na stránce [Logická disjunkce](https://en.wikipedia.org/wiki/Logical_disjunction) na Wikipedii.
-	
-	
-
-### Příklad
-```yaml
-
-!OR
-- !EQ
-  - !ARG popis
-  - neoprávněný přístup
-- !EQ
-  - !ARG důvod
-  - hrubá síla
-- !EQ
-  - !ARG zpráva
-  - Zjištěn malware
-```
-
-V tomto příkladu je výraz pravdivý, pokud je splněna některá z následujících podmínek:
-
-1. Pole `description` odpovídá řetězci "unauthorized access".
-2. Pole `důvod` odpovídá řetězci "brute force".
-3. Pole `message` odpovídá řetězci "malware detected".
+	Další informace naleznete na stránce [Logical disjunction](https://en.wikipedia.org/wiki/Logical_disjunction) na Wikipedii.
 
 
-### Bitwise `!OR`
+!!! example "Příklad"
+
+	```yaml
+
+	!OR
+	- !EQ
+	- !ARG popis
+	- neoprávněný přístup
+	- !EQ
+	- !ARG důvod
+	- hrubá síla
+	- !EQ
+	- !ARG zpráva
+	- Zjištěn malware
+	```
+
+	V tomto příkladu je výraz pravdivý, pokud je splněna některá z následujících podmínek:
+
+	1. Pole `description` odpovídá řetězci "unauthorized access".
+	2. Pole `reason` odpovídá řetězci "brute force".
+	3. Pole `message` odpovídá řetězci "malware detected".
+
+
+### Bitové `!OR`
 
 Pokud se `!OR` použije na celočíselné typy místo na logické, poskytuje bitové OR.
 
-### Příklad
+!!! example
+
+	```yaml
+	!OR
+	- 1 # Read access - přístup pro čtení (binární 001, desítková 1)
+	- 4 # Execute access - přístup pro spuštění (binárně 100, desítkově 4)
+	```
+
+	V tomto příkladu je výraz vyhodnocen jako 5.
+
+	Je to proto, že při bitové operaci `!OR` se každý odpovídající bit v binární reprezentaci obou čísel kombinuje pomocí výrazu `!OR`:
+
+	```
+	001 (přístup pro čtení)
+	100 (přístup pro spuštění)
+	---
+	101 (kombinovaná oprávnění)
+	```
+
+	Výraz vypočítá oprávnění s výslednou hodnotou (binární 101, desítková 5) z operace bitového OR, která kombinuje přístup ke čtení i ke spouštění.
+
+---
+
+## `!NOT`: Negace
+
+Logický výraz `!NOT` se používá k obrácení pravdivostní hodnoty podmínky.
+Používá se k vyloučení určitých podmínek, pokud nejsou splněny jiné podmínky.
+
+Typ: _Mapping_.
+
+
+### Synopsis
+
 ```yaml
-
-!OR
-- 1 # Přístup pro čtení (binární 001, desítková 1)
-- 4 # Vykonat přístup (binárně 100, desítkově 4)
-```
-
-V tomto příkladu je výraz vyhodnocen jako 5.
-
-Je to proto, že při bitové operaci `!OR` se každý odpovídající bit v binární reprezentaci obou čísel kombinuje pomocí výrazu `!OR`:
-
-```
-001 (přístup pro čtení)
-100 (přístup k vykonání)
----
-101 (kombinovaná oprávnění)
-```
-
-Výraz vypočítá oprávnění s výslednou hodnotou (binární 101, desítková 5) z operace bitového OR, která kombinuje přístup ke čtení i k vykonávání.
-
----
-
-## `!NOT`: . 
-
-Logický výraz `!NOT` se používá k obrácení pravdivostní hodnoty jedné podmínky.
-Používá se k vyloučení určitých podmínek, pokud nejsou splněny určité podmínky.
-
-Typ: Typ: _Mapování_.
-
-
-### Synopse
-
-```
 !NOT
 co: <expression>
 ```
@@ -177,20 +172,15 @@ co: <expression>
 
 !!! info "Negace"
 
-	
-	
 	Pro více informací pokračujte na stránku [Negation](https://en.wikipedia.org/wiki/Negation) na Wikipedii.
 	
 	
 
-### Bitová metoda `!NOT`
+### Bitové `!NOT`
 
 Pokud je zadáno celé číslo, pak `!NOT` vrátí hodnotu s převrácenými bity `what`.
 
 !!! tip
 
-	
-	
-	
 	Pokud chcete otestovat, že celé číslo není nula, použijte testovací výraz `!NE`.
 

--- a/cs/docs/expressions/logic.md
+++ b/cs/docs/expressions/logic.md
@@ -166,7 +166,7 @@ Typ: _Mapping_.
 
 ```yaml
 !NOT
-co: <expression>
+what: <expression>
 ```
 
 

--- a/cs/docs/expressions/logic.md
+++ b/cs/docs/expressions/logic.md
@@ -24,7 +24,7 @@ Používá se k vytváření přísnějších a přesnějších podmínek.
 
 Typ: _Sequence_
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !AND
@@ -86,7 +86,7 @@ Používá se k vytváření flexibilnějších a komplexnějších podmínek.
 
 Typ: _Sequence_
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !OR
@@ -162,7 +162,7 @@ Používá se k vyloučení určitých podmínek, pokud nejsou splněny jiné po
 Typ: _Mapping_.
 
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !NOT

--- a/cs/docs/expressions/logic.md
+++ b/cs/docs/expressions/logic.md
@@ -1,6 +1,6 @@
 ---
 git_commit_hash: b55fa3f
-title: Logika
+title: Logické
 ---
 
 # Logické výrazy

--- a/cs/docs/expressions/lookup.md
+++ b/cs/docs/expressions/lookup.md
@@ -1,6 +1,6 @@
 ---
 git_commit_hash: b55fa3f
-title: Vyhledávání
+title: Vyhledávací
 ---
 
 # Vyhledávací výrazy

--- a/cs/docs/expressions/lookup.md
+++ b/cs/docs/expressions/lookup.md
@@ -15,14 +15,14 @@ Typ: xxx _Mapping_.
 
 ---
 
-## `!GET`: Získat položku z vyhledávání
+## `!GET`: Získá položku z vyhledávání
 
 Typ: _Mapping_.
 
 
 ---
 
-## `!IN`: Zkontrolujte, zda je položka v seznamu vyhledávání.
+## `!IN`: Zkontroluje, zda je položka v seznamu vyhledávání.
 
 Typ: _Mapping_.
 

--- a/cs/docs/expressions/parsec.md
+++ b/cs/docs/expressions/parsec.md
@@ -166,34 +166,35 @@ Pole `min`, `max` a `přesně` jsou nepovinná.
 !!! example "Příklad"
 
 	_Vstupní řetězec:_ `jméno@123_`
-	```yaml
 
+	```yaml
 	!PARSE.CHARS
 	max: 8
 	```
+
 !!! tip
 
 	Pro analýzu až do konce řetězce použijte `!PARSE.CHARS` bez polí.
-	
-	
+
+
 <details>
 
  <summary>Další příklady</summary>
 
-Parsuje co nejvíce znaků:
+Parsování co nejvíce znaků:
 
 ```yaml
 !PARSE.CHARS
 ```
 
-Parsuje přesně 3 znaky:
+Parsování přesně 3 znaků:
 
 ```yaml
 !PARSE.CHARS
 exactly: 3
 ```
 
-Parsuje alespoň 2 znaky, ale ne více než 4:
+Parsováníe alespoň 2 znaků, ale ne více než 4:
 
 ```yaml
 !PARSE.CHARS
@@ -250,11 +251,11 @@ nebo kratší verze:
 !PARSE.ONEOF <...>
 ```
 
-!!! example
+!!! example "Příklad"
 
-	_Vstupní řetězec:_ `Wow`==!==
+	_Vstupní řetězec:_ `Wow!`
+
 	```yaml
-
 	!PARSE.ONEOF
 	what: "!?"
 	```
@@ -262,51 +263,53 @@ nebo kratší verze:
 
 ---
 
-## `!PARSE.NONEOF`: Parsování jednoho znaku, který není v množině znaků
+## `!PARSE.NONEOF`: Parsuje jeden znak, který není v množině znaků
 
 Typ: _Parser_.
 
 ### Synopsis
-```yaml
 
+```yaml
 !PARSE.NONEOF
 what: <...>
 ```
-nebo kratší verze:```yaml
-
+nebo kratší verze:
+```yaml
 !PARSE.NONEOF <...>
 ```
 
-## Příklad
-_Vstupní řetězec:_ `Wow`==!==
-```yaml
+!!! example "Příklad"
 
-!PARSE.NONEOF
-what: ",;:[]()"
-```
+	_Vstupní řetězec:_ `Wow!`
+
+	```yaml
+	!PARSE.NONEOF
+	what: ",;:[]()"
+	```
 
 
 ---
 
-## `!PARSE.UNTIL`: Parsovat posloupnost znaků, dokud není nalezen konkrétní znak.
+## `!PARSE.UNTIL`: Parsuje posloupnost znaků, dokud není nalezen konkrétní znak
 
 Typ: _Parser_.
 
 ### Synopsis
-```yaml
 
+```yaml
 !PARSE.UNTIL
 what: <...>
-stop: &lt;před/po&gt;
-eof: &lt;pravda/nepravda&gt;
+stop: <before/after>
+eof: <true/false>
 ```
-nebo kratší verze:```yaml
+nebo kratší verze:
 
+```yaml
 !PARSE.UNTIL <...>
 ```
 
 - `stop` - určuje, zda se má znak stop analyzovat nebo ne.
-			Možné hodnoty: `před` nebo `po`(výchozí).
+			Možné hodnoty: `before` nebo `after`(výchozí).
 
 - `eof` - udává, zda máme analyzovat až do konce řetězce, pokud není nalezen symbol `what`.
 			Možné hodnoty: `true` nebo `false`(výchozí).
@@ -314,44 +317,47 @@ nebo kratší verze:```yaml
 
 !!! info
 
-	
-	
-	
-		Pole `what` musí být jednoznakové. Lze však použít i některé bílé znaky, např. `tab`.
+		Pole `what` musí být jednoznakové. Lze však použít i některé bílé znaky, jako např. `tab`.
 	
 
-## Příklad
-_Vstupní řetězec:_ `60290:11`
-```yaml
+!!! example "Příklad"
 
-!PARSE.UNTIL
-what: ":"
-```
+	_Vstupní řetězec:_ `60290:11`
+
+	```yaml
+	!PARSE.UNTIL
+	what: ":"
+	```
+
 <details>
 
  <summary>Další příklady</summary>
 
-Parsujte až do symbolu <code>:</code> a zastavte se před ním:```yaml
+Parsování až do symbolu <code>:</code> a zastavení před ním:
 
+```yaml
 !PARSE.UNTIL
 what: ":"
 stop: "před"
 ```
 
-Parsování až do symbolu mezery a zastavení za ním:```yaml
+Parsování až do symbolu mezery a zastavení za ním:
 
+```yaml
 !PARSE.UNTIL ' '
 ```
 
-Parse until <code>,</code> symbol nebo parse until the end of the string if it's not found:```yaml
+Parsování až do symbolu <code>,</code> symbol nebo do konce řetězce, pokud není symbol nalezen.
 
+```yaml
 !PARSE.UNTIL
 what: ","
 eof: true
 ```
 
-Parse until symbol <code>tab</code>:```yaml
+Parsování do symbolu <code>tab</code>:
 
+```yaml
 !PARSE.UNTIL
 what: 'tab'
 ```
@@ -365,42 +371,47 @@ what: 'tab'
 Typ: _Parser_.
 
 ### Synopsis
-```yaml
 
+```yaml
 !PARSE.EXACTLY
 what: <...>
 ```
-nebo kratší verze:```yaml
 
+nebo kratší verze:
+
+```yaml
 !PARSE.EXACTLY <...>
 ```
 
-## Příklad
-_Vstupní řetězec:_ `Hello world!`
-```yaml
+!!! example "Příklad"
 
-!PARSE.EXACTLY
-what: "Hello"
-```
+	_Vstupní řetězec:_ `Hello world!`
+
+	```yaml
+	!PARSE.EXACTLY
+	what: "Hello"
+	```
 
 
 ---
 
-## `!PARSE.BETWEEN`: Parsování posloupnosti znaků mezi dvěma konkrétními znaky
+## `!PARSE.BETWEEN`: Parsuje posloupnost znaků mezi dvěma konkrétními znaky
 
 Typ: _Parser_.
 
 ### Synopsis
-```yaml
 
+```yaml
 !PARSE.BETWEEN
 what: <...>
 start: <...>
 stop: <...>
-únik: <...>
+escape: <...>
 ```
-nebo kratší verze:```yaml
 
+nebo kratší verze:
+
+```yaml
 !PARSE.BETWEEN <...>
 ```
 
@@ -411,36 +422,39 @@ nebo kratší verze:```yaml
 - `escape` - označuje znak escape.
 
 
-## Příklad
-_Vstupní řetězec:_ `[10/May/2023:08:15:54 +0000]`
-```yaml
+!!! example "Příklad"
 
-!PARSE.BETWEEN
-start: '['
-stop: ']'
-```
-<details>
+	_Vstupní řetězec:_ `[10/May/2023:08:15:54 +0000]`
+	```yaml
+
+	!PARSE.BETWEEN
+	start: '['
+	stop: ']'
+	```
+	<details>
 
  <summary>Další příklady</summary>
 
-Rozbor mezi dvojitými uvozovkami:```yaml
+Parsování mezi dvojitými uvozovkami:
 
+```yaml
 !PARSE.BETWEEN
 what: '"'
 ```
 
-Parsování mezi dvojitými uvozovkami, zkrácená forma:```yaml
+Parsování mezi dvojitými uvozovkami, zkrácená forma:
 
+```yaml
 !PARSE.BETWEEN '"'
 ```
 
-Parse mezi dvojitými uvozovkami, escape interních dvojitých uvozovek:<br>
+Parsování mezi dvojitými uvozovkami, přeskakuje interní dvojité uvozovky:<br>
 
 <i>Vstupní řetězec:</i><code>"jedna, "dva", tři"</code>
-```yaml
 
+```yaml
 !PARSE.BETWEEN
-what: '"
+what: '"'
 escape: '\'
 ```
 </details>
@@ -448,76 +462,79 @@ escape: '\'
 
 ---
 
-## `!PARSE.REGEX`: Parsování posloupnosti znaků, která odpovídá regulárnímu výrazu
+## `!PARSE.REGEX`: Parsuje posloupnost znaků, která odpovídá regulárnímu výrazu
 
 Typ: _Parser_.
 
 ### Synopsis
-```yaml
 
+```yaml
 !PARSE.REGEX
 what: <...>
 ```
 
-## Příklad
-_Vstupní řetězec:_ `FTVW23_L-C: `
+!!! example "Příklad"
 
-_Output string:_ `FTVW23_L-C`
-```yaml
+	_Vstupní řetězec:_ `FTVW23_L-C: Message...`
 
-!PARSE.REGEX
-what: '[a-zA-Z0-9_\-0]+'
-```
+	_Výstupní řetězec:_ `FTVW23_L-C`
+
+	```yaml
+	!PARSE.REGEX
+	what: '[a-zA-Z0-9_\-0]+'
+	```
 
 
 ---
 
-## `!PARSE.MONTH`: Parse a month name
+## `!PARSE.MONTH`: Parsuje jméno měsíce
 
 Typ: _Parser_.
 
 ### Synopsis
-```yaml
 
+```yaml
 !PARSE.MONTH
 what: <...>
 ```
-nebo kratší verze:```yaml
 
+nebo kratší verze:
+
+```yaml
 !PARSE.MONTH <...>
 ```
 
-- `what` - udává formát názvu měsíce.
-			Možné hodnoty: `číslo`, `krátký`, `úplný`.
+- `what` - udává formát názvu měsíce. Možné hodnoty: `number`, `short`, `full`.
 
 !!! tip
 
-	
-	
 	Pomocí `!PARSE.MONTH` analyzujete název měsíce jako součást `!PARSE.DATETIME`.
-	
-	
 
-## Příklad
-_Vstupní řetězec:_ `10/`==May==`/2023:08:15:54``
-```yaml
 
-!PARSE.MONTH
-what: 'short'
-```
+!!! example "Příklad"
+
+	_Vstupní řetězec:_ `10/`==May==`/2023:08:15:54`
+
+	```yaml
+	!PARSE.MONTH
+	what: 'short'
+	```
+
 <details>
 
  <summary>Další příklady</summary>
 
-Rozbor měsíce ve formátu čísla:<br>
-<i>Vstupní řetězec</i>:<code><mark>2003-10-11</mark></code>```yaml
+Parsování měsíce v číselném formátu:<br>
+<i>Vstupní řetězec</i>:<code><mark>2003-10-11</mark></code>
 
+```yaml
 !PARSE.MONTH 'číslo'
 ```
 
 Parsování měsíce v plném formátu:<br>
-<i>Vstupní řetězec:</i><code><mark>2003-OCTOBER-11</mark></code>```yaml
+<i>Vstupní řetězec:</i><code><mark>2003-OCTOBER-11</mark></code>
 
+```yaml
 !PARSE.MONTH
 what: 'full'
 ```
@@ -526,7 +543,7 @@ what: 'full'
 
 ---
 
-## `!PARSE.FRAC`: Parse a fraction
+## `!PARSE.FRAC`: Parsuje zlomek
 
 Typ: _Parser_.
 
@@ -545,20 +562,17 @@ max: <...>
 
 !!! tip
 
-	
-	
-	Pomocí `!PARSE.FRAC` můžete analyzovat mikrosekundy nebo nanosekundy jako součást `!PARSE.DATETIME`.
-	
-	
+	Pomocí `!PARSE.FRAC` lze analyzovat mikrosekundy nebo nanosekundy jako součást `!PARSE.DATETIME`.
 
-## Příklad
-_Vstupní řetězec:_ `Aug 22 05:40:14`==.264==
-```yaml
+!!! example "Příklad"
 
-!PARSE.FRAC
-base: "micro"
-max: 6
-```
+	_Vstupní řetězec:_ `Aug 22 05:40:14`==.264==
+
+	```yaml
+	!PARSE.FRAC
+	base: "micro"
+	max: 6
+	```
 
 
 ---
@@ -569,74 +583,78 @@ Typ: _Parser_.
 
 
 ### Synopsis
-```yaml
 
+```yaml
 !PARSE.DATETIME
 - year: <...>
-- měsíc: <...>
-- den: <...>
-- den: hodina: <...>
-- minuta: <...>
-- hodina: sekunda: <...>
-- nanosekunda: <...>
-- časové pásmo: <...>
+- month: <...>
+- day: <...>
+- hour: <...>
+- minute: <...>
+- second: <...>
+- nanosecond: <...>
+- timezone: <...>
 ```
 
-- Pole `měsíc`, `den` jsou povinná.
-- Pole `rok` je nepovinné. Pokud není zadáno, použije se funkce _smart year_.
-- Pole `hodina`, `minuta`, `sekunda`, `mikrosekunda`, `nanosekunda` jsou nepovinná. Pokud nejsou zadána, použije se výchozí hodnota 0.
-- Zadání pole mikrosekund jako `mikrosekundy?`, umožní analyzovat mikrosekundy nebo ne, záleží na jejich přítomnosti ve vstupním řetězci.
-- Pole `časová zóna` je nepovinné. Pokud není zadáno, použije se výchozí hodnota `UTC`.
-  - `Časové pásmo` lze zadat ve dvou různých formátech.
-	1. `Z`, `+08:00` - analyzuje se ze vstupního řetězce.
-	2. `Evropa/Praha` - zadáno jako konstantní hodnota.
+- Pole `month`, `day` jsou povinná.
+- Pole `year` je nepovinné. Pokud není zadáno, použije se funkce _smart year_.
+- Pole `hour`, `minute`, `second`, `microsecond`, `nanosecond` jsou nepovinná. Pokud nejsou zadána, použije se výchozí hodnota 0.
+- Zadání pole mikrosekund jako `microsecond?`, umožní parsovat mikrosekundy, pokud se vyskytují ve vstupním řetězci, a jinak ne.
+- Pole `timezone` je nepovinné. Pokud není zadáno, použije se výchozí hodnota `UTC`. Lze jej zadat ve dvou různých formátech.
+    1. `Z`, `+08:00` - analyzuje se ze vstupního řetězce.
+    2. `Evropa/Praha` - zadáno jako konstantní hodnota.
 
 
 ### Zkratky
 K dispozici jsou tvary zkratek (v obou nižších/vyšších variantách):
-```yaml
 
+```yaml
 !PARSE.DATETIME RFC3339
 ```
-```yaml
 
+```yaml
 !PARSE.DATETIME iso8601
 ```
 
-## Příklad
-_Vstupní řetězec:_ `2022-10-13T12:34:56.987654`
-```yaml
+!!! example "Příklad"
 
-!PARSE.DATETIME
-- rok: !PARSE.DIGITS
-- '-'
-- měsíc: !PARSE.MONTH 'číslo'
-- '-'
-- den: !PARSE.DIGITS
-- 'T'
-- hodina: !PARSE.DIGITS
-- ':'
-- minuta: !PARSE.DIGITS
-- ':'
-- sekunda: !PARSE.DIGITS
-- mikrosekunda: !PARSE.FRAC
-				base: "micro"
-				max: 6
-- časové pásmo: "Europe/Prague"
-```
+	_Vstupní řetězec:_ `2022-10-13T12:34:56.987654`
+	```yaml
+
+	!PARSE.DATETIME
+	- year: !PARSE.DIGITS
+	- '-'
+	- month: !PARSE.MONTH 'číslo'
+	- '-'
+	- day: !PARSE.DIGITS
+	- 'T'
+	- hour: !PARSE.DIGITS
+	- ':'
+	- minute: !PARSE.DIGITS
+	- ':'
+	- second: !PARSE.DIGITS
+	- microsecond: !PARSE.FRAC
+					base: "micro"
+					max: 6
+	- timezone: "Europe/Prague"
+	```
+
 <details>
+  <summary>Další příklady</summary>
 
- <summary>Další příklady</summary>
+Parsování data bez roku, s krátkým tvarem měsíce a volitelnými mikrosekundami:
 
-Parsování data bez roku, s krátkým tvarem měsíce a volitelnými mikrosekundami:<br>
-<i>Vstupní řetězec</i>: <code>Aug 17 06:57:05.189</code>```yaml
+<br>
 
+<i>Vstupní řetězec</i>: <code>Aug 17 06:57:05.189</code>
+
+```yaml
 !PARSE.DATETIME
-- měsíc: !PARSE.MONTH 'short' # Měsíc
+- month: !PARSE.MONTH 'short' # Měsíc
 - !PARSE.SPACE
 - day: !PARSE.DIGITS # Den
 - !PARSE.SPACE
-- hodina: !PARSE.DIGITS # Hodiny
+- hour: !PARSE.DIGITS # Hodiny
 - !PARSE.EXACTLY { what: ':' }
 - minute: !PARSE.DIGITS # Minuty
 - !PARSE.EXACTLY { what: ':' }
@@ -646,51 +664,56 @@ Parsování data bez roku, s krátkým tvarem měsíce a volitelnými mikrosekun
 				max: 6
 ```
 
-Parse datetime s časovou zónou:<br>
-<i>Vstupní řetězec:</i> <code>2021-06-29T16:51:43+08:00</code>```yaml
+Parse datetime s časovou zónou:
+<br>
+<i>Vstupní řetězec:</i> <code>2021-06-29T16:51:43+08:00</code>
 
+```yaml
 !PARSE.DATETIME
-- rok: !PARSE.DIGITS
+- year: !PARSE.DIGITS
 - '-'
-- měsíc: !PARSE.MONTH 'číslo'
+- month: !PARSE.MONTH 'číslo'
 - '-'
-- den: !PARSE.DIGITS
+- day: !PARSE.DIGITS
 - 'T'
-- hodina: !PARSE.DIGITS
+- hour: !PARSE.DIGITS
 - ':'
-- minuta: !PARSE.DIGITS
+- minute: !PARSE.DIGITS
 - ':'
-- sekunda: !PARSE.DIGITS
-- časové pásmo: !PARSE.CHARS
+- second: !PARSE.DIGITS
+- timezone: !PARSE.CHARS
 ```
 
 Parse datetime pomocí zkratky:<br>
-<i>Vstupní řetězec:</i> <code>2021-06-29T16:51:43Z</code>```yaml
+<i>Vstupní řetězec:</i> <code>2021-06-29T16:51:43Z</code>
 
+```yaml
 !PARSE.DATETIME RFC3339
 ```
 
 Parsování datetime pomocí zkratky:<br>
-<i>Vstupní řetězec:</i> <code>20201211T111721Z</code>```yaml
+<i>Vstupní řetězec:</i> <code>20201211T111721Z</code>
 
+```yaml
 !PARSE.DATETIME iso8601
 ```
 
 Parsování data s nanosekundami:<br>
-<i>Vstupní řetězec:</i> <code>2023-03-23T07:00:00.734323900</code>```yaml
+<i>Vstupní řetězec:</i> <code>2023-03-23T07:00:00.734323900</code>
 
+```yaml
 !PARSE.DATETIME
-- rok: !PARSE.DIGITS
+- year: !PARSE.DIGITS
 - !PARSE.EXACTLY { what: '-' }
 - month: !PARSE.DIGITS
 - !PARSE.EXACTLY { what: '-' }
-- den: !PARSE.DIGITS
+- day: !PARSE.DIGITS
 - !PARSE.EXACTLY { what: 'T' }
-- hodina: !PARSE.DIGITS
+- hour: !PARSE.DIGITS
 - !PARSE.EXACTLY { what: ':' }
-- minuta: !PARSE.DIGITS
+- minute: !PARSE.DIGITS
 - !PARSE.EXACTLY { what: ':' }
-- sekunda: !PARSE.DIGITS
+- second: !PARSE.DIGITS
 - nanosekunda: !PARSE.FRAC
   base: "nano"
   max: 9

--- a/cs/docs/expressions/parsec.md
+++ b/cs/docs/expressions/parsec.md
@@ -26,7 +26,7 @@ Každý výraz pro parsování začíná předponou `!PARSE.`.
 
 Typ: _Parser_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.DIGIT
@@ -47,7 +47,7 @@ Typ: _Parser_.
 
 Typ: _Parser_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.DIGITS
@@ -105,7 +105,7 @@ Latinská písmena od A do Z, malá i velká písmena.
 
 Typ: _Parser_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.LETTER
@@ -127,7 +127,7 @@ Jakýkoli typ znaku.
 
 Typ: _Parser_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.CHAR
@@ -148,7 +148,7 @@ Typ: _Parser_.
 
 Typ: _Parser_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.CHARS
@@ -211,7 +211,7 @@ max: 4
 
 Typ: _Parser_.
 
-### Synopsis
+Synopsis:
 ```yaml
 
 !PARSE.SPACE
@@ -226,7 +226,7 @@ Parsování co největšího počtu znaků mezery:
 
 Typ: _Parser_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.SPACES
@@ -239,7 +239,7 @@ Typ: _Parser_.
 
 Typ: _Parser_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.ONEOF
@@ -267,7 +267,7 @@ nebo kratší verze:
 
 Typ: _Parser_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.NONEOF
@@ -294,7 +294,7 @@ nebo kratší verze:
 
 Typ: _Parser_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.UNTIL
@@ -370,7 +370,7 @@ what: 'tab'
 
 Typ: _Parser_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.EXACTLY
@@ -399,7 +399,7 @@ nebo kratší verze:
 
 Typ: _Parser_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.BETWEEN
@@ -466,7 +466,7 @@ escape: '\'
 
 Typ: _Parser_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.REGEX
@@ -491,7 +491,7 @@ what: <...>
 
 Typ: _Parser_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.MONTH
@@ -547,7 +547,7 @@ what: 'full'
 
 Typ: _Parser_.
 
-### Synopsis
+Synopsis:
 ```yaml
 
 !PARSE.FRAC
@@ -582,7 +582,7 @@ max: <...>
 Typ: _Parser_.
 
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.DATETIME

--- a/cs/docs/expressions/parsec.md
+++ b/cs/docs/expressions/parsec.md
@@ -3,94 +3,93 @@ git_commit_hash: b55fa3f
 title: Parsec
 ---
 
-# Výrazy PARSEC
+# Výrazy pro PARSEC
 
 
-Skupina výrazů PARSEC představuje koncept [Parser combinator](https://en.wikipedia.org/wiki/Parser_combinator).
+Skupina výrazů PARSEC reprezentuje koncept [Parser combinator](https://en.wikipedia.org/wiki/Parser_combinator).
 
-Poskytují způsob, jak kombinovat základní parsery za účelem konstrukce složitějších parserů pro konkrétní pravidla.
+Poskytuje způsob, jak kombinovat základní parsery za účelem konstrukce složitějších parserů na základě určitých pravidel.
 V tomto kontextu je parser funkce, která přijímá řetězec jako vstup a vytváří strukturovaný výstup, který indikuje úspěšné parsování nebo poskytuje chybové hlášení, pokud proces parsování selže.
 
 Parsovací výrazy se dělí do dvou skupin: parsery a kombinátory.
 
-*Parsery* lze považovat za základní jednotky nebo stavební bloky. Jsou zodpovědné za rozpoznávání a zpracování konkrétních vzorů nebo prvků ve vstupním řetězci.
+_Parsery_ lze považovat za základní jednotky nebo stavební bloky. Jsou zodpovědné za rozpoznávání a zpracování konkrétních vzorů nebo prvků ve vstupním řetězci.
 
-*Kombinátory* jsou naproti tomu operátory nebo funkce, které umožňují kombinaci a skládání parserů.
+_Kombinátory_ jsou naproti tomu operátory nebo funkce, které umožňují kombinaci a skládání parserů.
 
-Každý výraz začíná předponou `!PARSE.`.
+Každý výraz pro parsování začíná předponou `!PARSE.`.
 
 
 ---
 
-## `!PARSE.DIGIT`: Parsovat jednu číslici
+## `!PARSE.DIGIT`: Parsuje jednu číslici
 
 Typ: _Parser_.
 
-### Synopse
-```yaml
+### Synopsis
 
+```yaml
 !PARSE.DIGIT
 ```
 
 
-### Příklad
-_Input string:_ `2`
-```yaml
+!!! example
 
-!PARSE.DIGIT
-```
+	_Vstupní řetězec:_ `2`
+
+	```yaml
+	!PARSE.DIGIT
+	```
 
 ---
 
-## `!PARSE.DIGITS`: Parsování posloupnosti číslic
+## `!PARSE.DIGITS`: Parsuje více číslic
 
 Typ: _Parser_.
 
-### Synopse
+### Synopsis
 
 ```yaml
-
 !PARSE.DIGITS
 min: <...>
 max: <...>
-přesně: <...>
+exactly: <...>
 ```
-Pole `min`, `max` a `přesně` jsou nepovinná.
 
-!!! warning
+Pole `min`, `max` a `exactly` jsou nepovinná.
 
-	
-	
-	
+!!! warning "Varování"
+
 	Pole `Exactly` nelze použít společně s poli `min` nebo `max`. A samozřejmě hodnota `max` nesmí být menší než hodnota `min`.
-	
-	
-	
 
-### Příklad
-_Input string:_ `123`
-```yaml
+!!! example "Příklad"
 
-!PARSE.DIGITS
-max: 4
-```
+	_Vstupní řetězec:_ `123`
+
+	```yaml
+	!PARSE.DIGITS
+	max: 4
+	```
 <details>
 
  <summary>Další příklady</summary>
 
-Rozeberte co nejvíce číslic:```yaml
+Parsování co nejvíce číslic:
 
+```yaml
 !PARSE.DIGITS
 ```
 
-Parsovat přesně 3 číslice:```yaml
+Parsování přesně tří číslic:
 
+```yaml
 !PARSE.DIGITS
-přesně: 3
+exactly: 3
 ```
 
-Parsovat alespoň 2 číslice, ale ne více než 4:```yaml
+Parsování alespoň dvou číslic, ale ne více než čtyř:
 
+```yaml
 !PARSE.DIGITS
 min: 2
 max: 4
@@ -101,81 +100,79 @@ max: 4
 
 ---
 
-## `!PARSE.LETTER`: Parsovat jedno písmeno
+## `!PARSE.LETTER`: Parsuje jedno písmeno
 Latinská písmena od A do Z, malá i velká písmena.
 
 Typ: _Parser_.
 
-### Synopse
-```yaml
+### Synopsis
 
+```yaml
 !PARSE.LETTER
 ```
 
-### Příklad
-_Input string:_ `A`
-```yaml
+!!! example "Příklad"
 
-!PARSE.LETTER
-```
+	_Vstupní řetězec:_ `A`
+
+	```yaml
+	!PARSE.LETTER
+	```
 
 
 ---
 
-## `!PARSE.CHAR`: Parsování jednoho znaku
+## `!PARSE.CHAR`: Parsuje jeden znak
 Jakýkoli typ znaku.
 
 Typ: _Parser_.
 
-### Synopse
+### Synopsis
+
 ```yaml
-
 !PARSE.CHAR
 ```
 
-### Příklad
-_Input string:_ `@````yaml
+!!! example "Příklad"
 
-!PARSE.CHAR
-```
+	_Vstupní řetězec:_ `@`
+
+	```yaml
+	!PARSE.CHAR
+	```
 
 
 ---
 
-## `!PARSE.CHARS`: Parsovat posloupnost znaků
+## `!PARSE.CHARS`: Parsuje posloupnost znaků
 
 Typ: _Parser_.
 
-### Synopse
-```yaml
+### Synopsis
 
+```yaml
 !PARSE.CHARS
 min: <...>
 max: <...>
-přesně: <...>
+exactly: <...>
 ```
 Pole `min`, `max` a `přesně` jsou nepovinná.
 
-!!! warning
+!!! warning "Varování"
 
-	
-	
-	
 	Pole `Exactly` nelze použít společně s poli `min` nebo `max`. A samozřejmě hodnota `max` nesmí být menší než hodnota `min`.
-	
 
-### Příklad
-_Vstupní řetězec:_ `jméno@123_`
-```yaml
 
-!PARSE.CHARS
-max: 8
-```
+!!! example "Příklad"
+
+	_Vstupní řetězec:_ `jméno@123_`
+	```yaml
+
+	!PARSE.CHARS
+	max: 8
+	```
 !!! tip
 
-	
-	
-	
 	Pro analýzu až do konce řetězce použijte `!PARSE.CHARS` bez polí.
 	
 	
@@ -183,19 +180,22 @@ max: 8
 
  <summary>Další příklady</summary>
 
-Analyzujte co nejvíce znaků:```yaml
+Parsuje co nejvíce znaků:
 
+```yaml
 !PARSE.CHARS
 ```
 
-Parsovat přesně 3 znaky:```yaml
+Parsuje přesně 3 znaky:
 
+```yaml
 !PARSE.CHARS
-přesně: 3
+exactly: 3
 ```
 
-Parsujte alespoň 2 znaky, ale ne více než 4:```yaml
+Parsuje alespoň 2 znaky, ale ne více než 4:
 
+```yaml
 !PARSE.CHARS
 min: 2
 max: 4
@@ -206,11 +206,11 @@ max: 4
 
 ---
 
-## `!PARSE.SPACE`: Parsování jednoho znaku mezery
+## `!PARSE.SPACE`: Parsuje jednu mezeru
 
 Typ: _Parser_.
 
-### Synopse
+### Synopsis
 ```yaml
 
 !PARSE.SPACE
@@ -219,43 +219,45 @@ Typ: _Parser_.
 
 ---
 
-## `!PARSE.SPACES`: Parsovat posloupnost znaků mezery
+## `!PARSE.SPACES`: Parsuje více mezer
 
 Parsování co největšího počtu znaků mezery:
 
 Typ: _Parser_.
 
-### Synopse
-```yaml
+### Synopsis
 
+```yaml
 !PARSE.SPACES
 ```
 
 
 ---
 
-## `!PARSE.ONEOF`: Parsování jednoho znaku z množiny znaků
+## `!PARSE.ONEOF`: Parsuje jeden znak z množiny znaků
 
 Typ: _Parser_.
 
-### Synopse
+### Synopsis
+
 ```yaml
-
 !PARSE.ONEOF
-co: <...>
+what: <...>
 ```
-nebo kratší verze:```yaml
+nebo kratší verze:
 
+```yaml
 !PARSE.ONEOF <...>
 ```
 
-## Příklad
-_Input string:_ `Wow`==!==
-```yaml
+!!! example
 
-!PARSE.ONEOF
-co: "!?"
-```
+	_Vstupní řetězec:_ `Wow`==!==
+	```yaml
+
+	!PARSE.ONEOF
+	what: "!?"
+	```
 
 
 ---
@@ -264,11 +266,11 @@ co: "!?"
 
 Typ: _Parser_.
 
-### Synopse
+### Synopsis
 ```yaml
 
 !PARSE.NONEOF
-co: <...>
+what: <...>
 ```
 nebo kratší verze:```yaml
 
@@ -276,11 +278,11 @@ nebo kratší verze:```yaml
 ```
 
 ## Příklad
-_Input string:_ `Wow`==!==
+_Vstupní řetězec:_ `Wow`==!==
 ```yaml
 
 !PARSE.NONEOF
-co: ",;:[]()"
+what: ",;:[]()"
 ```
 
 
@@ -290,11 +292,11 @@ co: ",;:[]()"
 
 Typ: _Parser_.
 
-### Synopse
+### Synopsis
 ```yaml
 
 !PARSE.UNTIL
-co: <...>
+what: <...>
 stop: &lt;před/po&gt;
 eof: &lt;pravda/nepravda&gt;
 ```
@@ -304,10 +306,10 @@ nebo kratší verze:```yaml
 ```
 
 - `stop` - určuje, zda se má znak stop analyzovat nebo ne.
-            Možné hodnoty: `před` nebo `po`(výchozí).
+			Možné hodnoty: `před` nebo `po`(výchozí).
 
 - `eof` - udává, zda máme analyzovat až do konce řetězce, pokud není nalezen symbol `what`.
-            Možné hodnoty: `true` nebo `false`(výchozí).
+			Možné hodnoty: `true` nebo `false`(výchozí).
 
 
 !!! info
@@ -315,7 +317,7 @@ nebo kratší verze:```yaml
 	
 	
 	
-	    Pole `what` musí být jednoznakové. Lze však použít i některé bílé znaky, např. `tab`.
+		Pole `what` musí být jednoznakové. Lze však použít i některé bílé znaky, např. `tab`.
 	
 
 ## Příklad
@@ -332,7 +334,7 @@ what: ":"
 Parsujte až do symbolu <code>:</code> a zastavte se před ním:```yaml
 
 !PARSE.UNTIL
-co: ":"
+what: ":"
 stop: "před"
 ```
 
@@ -344,14 +346,14 @@ Parsování až do symbolu mezery a zastavení za ním:```yaml
 Parse until <code>,</code> symbol nebo parse until the end of the string if it's not found:```yaml
 
 !PARSE.UNTIL
-co: ","
+what: ","
 eof: true
 ```
 
 Parse until symbol <code>tab</code>:```yaml
 
 !PARSE.UNTIL
-co: 'tab'
+what: 'tab'
 ```
 </details>
 
@@ -362,11 +364,11 @@ co: 'tab'
 
 Typ: _Parser_.
 
-### Synopse
+### Synopsis
 ```yaml
 
 !PARSE.EXACTLY
-co: <...>
+what: <...>
 ```
 nebo kratší verze:```yaml
 
@@ -374,11 +376,11 @@ nebo kratší verze:```yaml
 ```
 
 ## Příklad
-_Input string:_ `Hello world!`
+_Vstupní řetězec:_ `Hello world!`
 ```yaml
 
 !PARSE.EXACTLY
-co: "Hello"
+what: "Hello"
 ```
 
 
@@ -388,11 +390,11 @@ co: "Hello"
 
 Typ: _Parser_.
 
-### Synopse
+### Synopsis
 ```yaml
 
 !PARSE.BETWEEN
-co: <...>
+what: <...>
 start: <...>
 stop: <...>
 únik: <...>
@@ -410,7 +412,7 @@ nebo kratší verze:```yaml
 
 
 ## Příklad
-_Input string:_ `[10/May/2023:08:15:54 +0000]`
+_Vstupní řetězec:_ `[10/May/2023:08:15:54 +0000]`
 ```yaml
 
 !PARSE.BETWEEN
@@ -450,21 +452,21 @@ escape: '\'
 
 Typ: _Parser_.
 
-### Synopse
+### Synopsis
 ```yaml
 
 !PARSE.REGEX
-co: <...>
+what: <...>
 ```
 
 ## Příklad
-_Input string:_ `FTVW23_L-C: `
+_Vstupní řetězec:_ `FTVW23_L-C: `
 
 _Output string:_ `FTVW23_L-C`
 ```yaml
 
 !PARSE.REGEX
-co: '[a-zA-Z0-9_\-0]+'
+what: '[a-zA-Z0-9_\-0]+'
 ```
 
 
@@ -474,11 +476,11 @@ co: '[a-zA-Z0-9_\-0]+'
 
 Typ: _Parser_.
 
-### Synopse
+### Synopsis
 ```yaml
 
 !PARSE.MONTH
-co: <...>
+what: <...>
 ```
 nebo kratší verze:```yaml
 
@@ -486,7 +488,7 @@ nebo kratší verze:```yaml
 ```
 
 - `what` - udává formát názvu měsíce.
-            Možné hodnoty: `číslo`, `krátký`, `úplný`.
+			Možné hodnoty: `číslo`, `krátký`, `úplný`.
 
 !!! tip
 
@@ -497,7 +499,7 @@ nebo kratší verze:```yaml
 	
 
 ## Příklad
-_Input string:_ `10/`==May==`/2023:08:15:54``
+_Vstupní řetězec:_ `10/`==May==`/2023:08:15:54``
 ```yaml
 
 !PARSE.MONTH
@@ -517,7 +519,7 @@ Parsování měsíce v plném formátu:<br>
 <i>Vstupní řetězec:</i><code><mark>2003-OCTOBER-11</mark></code>```yaml
 
 !PARSE.MONTH
-co: 'full'
+what: 'full'
 ```
 </details>
 
@@ -528,7 +530,7 @@ co: 'full'
 
 Typ: _Parser_.
 
-### Synopse
+### Synopsis
 ```yaml
 
 !PARSE.FRAC
@@ -537,9 +539,9 @@ max: <...>
 ```
 
 - `base` - udává základ zlomku.
-            Možné hodnoty: `milli`, `micro`, `nano`.
+			Možné hodnoty: `milli`, `micro`, `nano`.
 - `max` - udává maximální počet číslic v závislosti na hodnotě `base`.
-            Možné hodnoty: `3`, `6`, `9`.
+			Možné hodnoty: `3`, `6`, `9`.
 
 !!! tip
 
@@ -566,7 +568,7 @@ max: 6
 Typ: _Parser_.
 
 
-### Synopse
+### Synopsis
 ```yaml
 
 !PARSE.DATETIME
@@ -586,8 +588,8 @@ Typ: _Parser_.
 - Zadání pole mikrosekund jako `mikrosekundy?`, umožní analyzovat mikrosekundy nebo ne, záleží na jejich přítomnosti ve vstupním řetězci.
 - Pole `časová zóna` je nepovinné. Pokud není zadáno, použije se výchozí hodnota `UTC`.
   - `Časové pásmo` lze zadat ve dvou různých formátech.
-    1. `Z`, `+08:00` - analyzuje se ze vstupního řetězce.
-    2. `Evropa/Praha` - zadáno jako konstantní hodnota.
+	1. `Z`, `+08:00` - analyzuje se ze vstupního řetězce.
+	2. `Evropa/Praha` - zadáno jako konstantní hodnota.
 
 
 ### Zkratky
@@ -602,7 +604,7 @@ K dispozici jsou tvary zkratek (v obou nižších/vyšších variantách):
 ```
 
 ## Příklad
-_Input string:_ `2022-10-13T12:34:56.987654`
+_Vstupní řetězec:_ `2022-10-13T12:34:56.987654`
 ```yaml
 
 !PARSE.DATETIME
@@ -618,8 +620,8 @@ _Input string:_ `2022-10-13T12:34:56.987654`
 - ':'
 - sekunda: !PARSE.DIGITS
 - mikrosekunda: !PARSE.FRAC
-                base: "micro"
-                max: 6
+				base: "micro"
+				max: 6
 - časové pásmo: "Europe/Prague"
 ```
 <details>
@@ -640,8 +642,8 @@ Parsování data bez roku, s krátkým tvarem měsíce a volitelnými mikrosekun
 - !PARSE.EXACTLY { what: ':' }
 - second: !PARSE.DIGITS # Sekundy
 - microsecond?: !PARSE.FRAC # Mikrosekundy
-                base: "micro"
-                max: 6
+				base: "micro"
+				max: 6
 ```
 
 Parse datetime s časovou zónou:<br>

--- a/cs/docs/expressions/record.md
+++ b/cs/docs/expressions/record.md
@@ -25,11 +25,11 @@ Položky záznamu jsou pojmenovány (na rozdíl od tuplu) pomocí štítku.
 
 Typ:  _Mapping_.
 
-### Synopse
+### Synopsis
 ```yaml
 
 !RECORD
-s:
+with:
   item1: <item 1>
   item2: <item 2>
   ...
@@ -44,7 +44,7 @@ Pořadí položek je zachováno.
 ```yaml
 
 !RECORD
-s:
+with:
   jméno: John Doe
   věk: 37 let
   výška: 175,4
@@ -54,7 +54,7 @@ s:
 Použití formuláře toku YAML:
 ```yaml
 
-!RECORD {s: {jméno: John Doe, věk: 37 let, výška: 175,4} }
+!RECORD {with: {jméno: John Doe, věk: 37 let, výška: 175,4} }
 ```
 
 
@@ -69,7 +69,7 @@ Vynucení konkrétního typu položky:
 ```yaml
 
 !RECORD
-s:
+with:
   jméno: John Doe
   věk: !!ui8 37
   výška: 175,4
@@ -84,11 +84,11 @@ Pole `age` bude mít typ `ui8`.
 
 Typ: _Mapping_.
 
-### Synopse
+### Synopsis
 ```yaml
 
 !GET
-co: <name or index of the item>
+what: <name or index of the item>
 z: <record>
 ```
 
@@ -109,7 +109,7 @@ Použití názvů položek:
 what: name
 from:
   !RECORD
-  s:
+  with:
     jméno: John Doe
     věk: 32 let
     výška: 127,5
@@ -122,10 +122,10 @@ Pomocí _indexu_ položek:
 ```yaml
 
 !GET
-co: 1
+what: 1
 od:
   !RECORD
-  s:
+  with:
     jméno: John Doe
     věk: 32 let
     výška: 127,5
@@ -138,7 +138,7 @@ Používá _záporný index_ položek:
 ```yaml
 
 !GET
-co: -1
+what: -1
 od:
   !RECORD
   with:

--- a/cs/docs/expressions/record.md
+++ b/cs/docs/expressions/record.md
@@ -1,23 +1,17 @@
 ---
 git_commit_hash: b55fa3f
-title: Záznamové
+title: Záznamy
 ---
 
-# Záznam výrazů
+# Výrazy pro záznam
 
+Záznam (record) je jednou ze základních datových struktur poskytovaných SP-Langem.
+Jedná se o kolekci položek, které mohou mít různé typy.
+Položky záznamu jsou pojmenovány (na rozdíl od tuple) pomocí štítku (label).
 
+!!! note "Poznámka"
 
-Záznam je jednou ze základních datových struktur poskytovaných SP-Langem.
-Záznam je kolekce položek, případně různých typů.
-Položky záznamu jsou pojmenovány (na rozdíl od tuplu) pomocí štítku.
-
-!!! note
-
-	
-	
-	
 	Záznam je postaven na `!TUPLE`.
-	
 
 --- 
 
@@ -25,9 +19,9 @@ Položky záznamu jsou pojmenovány (na rozdíl od tuplu) pomocí štítku.
 
 Typ:  _Mapping_.
 
-### Synopsis
-```yaml
+Synopsis:
 
+```yaml
 !RECORD
 with:
   item1: <item 1>
@@ -40,56 +34,57 @@ with:
 Počet položek v záznamu není omezen.
 Pořadí položek je zachováno.
 
-### Příklady
-```yaml
+!!! example "Příklad"
 
-!RECORD
-with:
-  jméno: John Doe
-  věk: 37 let
-  výška: 175,4
-```
+	```yaml
+	!RECORD
+	with:
+	  jméno: John Doe
+	  věk: 37 let
+	  výška: 175,4
+	```
 
+!!! example "Příklad ve flow-formě:"
 
-Použití formuláře toku YAML:
-```yaml
+	```yaml
+	!RECORD {with: {jméno: John Doe, věk: 37 let, výška: 175,4} }
+	```
 
-!RECORD {with: {jméno: John Doe, věk: 37 let, výška: 175,4} }
-```
-
-
-Použití tagu `!!record`:
-```yaml
-
-{jméno: John Doe, věk: 37 let, výška: 175,4}
-```
+!!! example "Použití tagu `!!record`:"
 
 
-Vynucení konkrétního typu položky:
-```yaml
 
-!RECORD
-with:
-  jméno: John Doe
-  věk: !!ui8 37
-  výška: 175,4
-```
+	```yaml
+	{jméno: John Doe, věk: 37 let, výška: 175,4}
+	```
 
-Pole `age` bude mít typ `ui8`.
+!!! example
+
+	Vynucení konkrétního typu položky:
+
+	```yaml
+	!RECORD
+	with:
+	  jméno: John Doe
+	  věk: !!ui8 37
+	  výška: 175,4
+	```
+
+	Pole `age` bude mít typ `ui8`.
 
 
 --- 
 
-## `!GET`: Získat položku ze záznamu 
+## `!GET`: Získá položku ze záznamu
 
 Typ: _Mapping_.
 
-### Synopsis
-```yaml
+Synopsis:
 
+```yaml
 !GET
 what: <name or index of the item>
-z: <record>
+from: <record>
 ```
 
 Pokud je `what` řetězec, pak je to název pole v záznamu.
@@ -100,51 +95,49 @@ Položky jsou indexovány od 0, to znamená, že první položka v seznamu má i
 Pokud je `what` mimo hranice seznamu, příkaz se vrátí s chybou.
 
 
-### Příklady
-
-Použití názvů položek:
-```yaml
-
-!GET
-what: name
-from:
-  !RECORD
-  with:
-    jméno: John Doe
-    věk: 32 let
-    výška: 127,5
-```
-
-Vrátí `John Doe`.
+!!! example "Příklad použití názvů položek:"
 
 
-Pomocí _indexu_ položek:
-```yaml
+	```yaml
+	!GET
+	what: name
+	from:
+	  !RECORD
+	  with:
+	    jméno: John Doe
+	    věk: 32 let
+	    výška: 127,5
+	```
 
-!GET
-what: 1
-od:
-  !RECORD
-  with:
-    jméno: John Doe
-    věk: 32 let
-    výška: 127,5
-```
+	Vrátí `John Doe`.
 
-Vrací `32`, hodnotu položky `age`.
+!!! example "Použití _indexu_ položek:"
+
+	```yaml
+	!GET
+	what: 1
+	from:
+	  !RECORD
+	-  with:
+	    name: John Doe
+	    age: 32
+	    height: 127.5
+	```
+
+	Vrací `32`, hodnotu položky `age`.
 
 
-Používá _záporný index_ položek:
-```yaml
+!!! example "Použití _záporného indexu_ položek:"
 
-!GET
-what: -1
-od:
-  !RECORD
-  with:
-    jméno: John Doe
-    věk: 32 let
-    výška: 127,5
-```
+	```yaml
+	!GET
+	what: -1
+	from:
+	  !RECORD
+	  with:
+		name: John Doe
+		age: 32
+		height: 127.5
+	```
 
-Vrací `127.5`, hodnotu položky `height`.
+	Vrací `127.5`, hodnotu položky `height`.

--- a/cs/docs/expressions/record.md
+++ b/cs/docs/expressions/record.md
@@ -1,6 +1,6 @@
 ---
 git_commit_hash: b55fa3f
-title: Záznam
+title: Záznamové
 ---
 
 # Záznam výrazů

--- a/cs/docs/expressions/regex.md
+++ b/cs/docs/expressions/regex.md
@@ -8,26 +8,23 @@ title: Regex
 
 !!! tip
 
-	
-	
-	
-	Pomocí [Regexr](https://regexr.com) můžete vytvářet a testovat regulární výrazy.
-	
+    Pomocí [Regexr](https://regexr.com) můžete vytvářet a testovat regulární výrazy.
+
 
 --- 
 
 ## `!REGEX`: Vyhledávání pomocí regulárních výrazů  
 
-Typ: Typ: _Mapování_.
+Typ: _Mapping_.
 
 Synopsis:
-```yaml
 
+```yaml
 !REGEX
 what: <string>
 regex: <regex>
-trefa: <hit>
-REGEX: chybí: <miss>
+hit: <hit>
+miss: <miss>
 ```
 
 Projde řetězec `what` a hledá libovolné místo, kde regulární výraz `regex` dává shodu.
@@ -38,39 +35,39 @@ Výraz `hit` je nepovinný, výchozí hodnota je `true`.
 Výraz `miss` je nepovinný, výchozí hodnota je `false`.
 
 
-### Příklad
-```yaml
+!!! example "Příklad"
 
-!IF
-test:
-  !REGEX
-  what: "Hello world!"
-  regex: "world"
-then:
-  "Ano :-)"
-else:
-  "Ne ;-("
+    ```yaml
+    !IF
+    test:
+      !REGEX
+      what: "Hello world!"
+      regex: "world"
+    then:
+      "Yes :-)"
+    else:
+      "No ;-("
 ```
 
-Výše uvedený příklad lze zapsat také jako:
- ```yaml
+!!! example "Jiná forma:"
 
-!REGEX
-what: "Hello world!"
-regex: "world"
-hit: "Ano :-)"
-miss: "Ne ;-("
-```
+    ```yaml
+    !REGEX
+    what: "Hello world!"
+    regex: "world"
+    hit: "Ano :-)"
+    miss: "Ne ;-("
+    ```
 
 --- 
 
-## `!REGEX.REPLACE`: Regulární výraz nahradit  
+## `!REGEX.REPLACE`: Nahrazení regulárním výrazem
 
-Typ: Typ: _Mapování_.
+Typ: _Mapping_.
 
 Synopsis:
-```yaml
 
+```yaml
 !REGEX.REPLACE
 what: <string>
 regex: <regex>
@@ -80,26 +77,27 @@ by: <string>
 Nahradit regulární výraz `regex` odpovídající hodnotě `what` hodnotou `by`.
 
 
-### Příklad
-```yaml
+!!! example
 
-!REGEX.REPLACE
-what: "Hello world!"
-regex: "world"
-by: "Mars"
-```
+    ```yaml
 
-Vrací: `Hello Mars!`
+    !REGEX.REPLACE
+    what: "Hello world!"
+    regex: "world"
+    by: "Mars"
+    ```
+
+    Vrací: `Hello Mars!`
 
 --- 
 
 ## `!REGEX.SPLIT`: Rozdělí řetězec pomocí regulárního výrazu  
 
-Typ: Typ: _Mapování_.
+Typ: _Mapping_.
 
 Synopsis:
-```yaml
 
+```yaml
 !REGEX.SPLIT
 what: <string>
 regex: <regex>
@@ -111,45 +109,46 @@ Dělí řetězec `what` regulárním výrazem `regex`.
 Nepovinný argument `max` určuje maximální počet rozdělení.
 
 
-### Příklad
-```yaml
+!!! example "Příklad"
 
-!REGEX.SPLIT
-what: "07/14/2007 12:34:56"
-regex: "[/ :]"
-```
+    ```yaml
+    !REGEX.SPLIT
+    what: "07/14/2007 12:34:56"
+    regex: "[/ :]"
+    ```
 
-Vrací: `['07', '14', '2007', '12', '34', '56']`
+    Vrací: `['07', '14', '2007', '12', '34', '56']`
 
 --- 
 
 ## `!REGEX.FINDALL`: Najde všechny výskyty podle regulárního výrazu  
 
-Typ: Typ: _Mapování_.
+Typ: _Mapping_.
 
 Synopsis:
-```yaml
 
+```yaml
 !REGEX.FINDALL
 what: <string>
 regex: <regex>
 ```
 
-Najít všechny shody `regex` v řetězci `what`.
+Najde všechny shody `regex` v řetězci `what`.
 
-### Příklad
-```yaml
+!!! example "Příklad"
 
-!REGEX.FINDALL
-what: "Frodo, Sam, Gandalf, Legolas, Gimli, Aragorn, Boromir, Smíšek, Pipin"
-regex: \w+
-```
+    ```yaml
+    !REGEX.FINDALL
+    what: "Frodo, Sam, Gandalf, Legolas, Gimli, Aragorn, Boromir, Smíšek, Pipin"
+    regex: \w+
+    ```
 
-Vrací: `['Frodo', 'Sam', 'Gandalf', 'Legolas', 'Gimli', 'Aragorn', 'Boromir', 'Merry', 'Pippin']`
+    Vrací: `['Frodo', 'Sam', 'Gandalf', 'Legolas', 'Gimli', 'Aragorn', 'Boromir', 'Smíšek', 'Pipin']`
 
 ---
 
 ## `!REGEX.PARSE`: Parsování pomocí regulárního výrazu 
 
-Typ: _Mapování_.
+Type: _Mapping_.
 
+Viz kapitolu [`!PARSE.REGEX`](../parsec/#parseregex-parsuje-posloupnost-znaku-ktera-odpovida-regularnimu-vyrazu)

--- a/cs/docs/expressions/regex.md
+++ b/cs/docs/expressions/regex.md
@@ -20,11 +20,11 @@ title: Regex
 
 Typ: Typ: _Mapování_.
 
-### Synopse
+### Synopsis
 ```yaml
 
 !REGEX
-co: <string>
+what: <string>
 regex: <regex>
 trefa: <hit>
 REGEX: chybí: <miss>
@@ -56,7 +56,7 @@ Výše uvedený příklad lze zapsat také jako:
  ```yaml
 
 !REGEX
-co: "Hello world!"
+what: "Hello world!"
 regex: "world"
 hit: "Ano :-)"
 miss: "Ne ;-("
@@ -68,11 +68,11 @@ miss: "Ne ;-("
 
 Typ: Typ: _Mapování_.
 
-### Synopse
+### Synopsis
 ```yaml
 
 !REGEX.REPLACE
-co: <string>
+what: <string>
 regex: <regex>
 by: <string>
 ```
@@ -84,7 +84,7 @@ Nahradit regulární výraz `regex` odpovídající hodnotě `what` hodnotou `by
 ```yaml
 
 !REGEX.REPLACE
-co: "Hello world!"
+what: "Hello world!"
 regex: "world"
 by: "Mars"
 ```
@@ -97,11 +97,11 @@ Vrací: `Hello Mars!`
 
 Typ: Typ: _Mapování_.
 
-### Synopse
+### Synopsis
 ```yaml
 
 !REGEX.SPLIT
-co: <string>
+what: <string>
 regex: <regex>
 max: <integer>
 ```
@@ -115,7 +115,7 @@ Nepovinný argument `max` určuje maximální počet rozdělení.
 ```yaml
 
 !REGEX.SPLIT
-co: "07/14/2007 12:34:56"
+what: "07/14/2007 12:34:56"
 regex: "[/ :]"
 ```
 
@@ -127,11 +127,11 @@ Vrací: `['07', '14', '2007', '12', '34', '56']`
 
 Typ: Typ: _Mapování_.
 
-### Synopse
+### Synopsis
 ```yaml
 
 !REGEX.FINDALL
-co: <string>
+what: <string>
 regex: <regex>
 ```
 
@@ -141,7 +141,7 @@ Najít všechny shody `regex` v řetězci `what`.
 ```yaml
 
 !REGEX.FINDALL
-co: "Frodo, Sam, Gandalf, Legolas, Gimli, Aragorn, Boromir, Smíšek, Pipin"
+what: "Frodo, Sam, Gandalf, Legolas, Gimli, Aragorn, Boromir, Smíšek, Pipin"
 regex: \w+
 ```
 

--- a/cs/docs/expressions/regex.md
+++ b/cs/docs/expressions/regex.md
@@ -20,7 +20,7 @@ title: Regex
 
 Typ: Typ: _Mapování_.
 
-### Synopsis
+Synopsis:
 ```yaml
 
 !REGEX
@@ -68,7 +68,7 @@ miss: "Ne ;-("
 
 Typ: Typ: _Mapování_.
 
-### Synopsis
+Synopsis:
 ```yaml
 
 !REGEX.REPLACE
@@ -97,7 +97,7 @@ Vrací: `Hello Mars!`
 
 Typ: Typ: _Mapování_.
 
-### Synopsis
+Synopsis:
 ```yaml
 
 !REGEX.SPLIT
@@ -127,7 +127,7 @@ Vrací: `['07', '14', '2007', '12', '34', '56']`
 
 Typ: Typ: _Mapování_.
 
-### Synopsis
+Synopsis:
 ```yaml
 
 !REGEX.FINDALL

--- a/cs/docs/expressions/set.md
+++ b/cs/docs/expressions/set.md
@@ -1,76 +1,78 @@
 ---
 git_commit_hash: b55fa3f
-title: Množinové
+title: Množiny
 ---
 
-# Nastavení výrazu
+# Výrazy pro práci s množinami
 
 
-Sada ukládá jedinečné položky bez konkrétního pořadí.
-Položky v sadě musí být stejného typu.
+Množina (set) ukládá objekty zvané prvky, aniž by si všímala konkrétního pořadí, a každý prvek ukládá pouze jednou.
+Prvky v množině musí být stejného typu.
 Množina je jednou ze základních datových struktur poskytovaných jazykem SP-Lang.
 
-Množina je nejvhodnější pro testování hodnoty příslušnosti spíše než pro získání konkrétního prvku z množiny.
+Množina je vhodnější pro testování výskytu nějakého prvku spíše než pro získání konkrétního prvku.
 
 --- 
 
 ## `!SET`: množina prvků 
 
-Typ:  _Implicitní posloupnost_, _Mapování_.
+Typ: _Implicit sequence_, _Mapping_.
 
 Synopsis:
-```yaml
 
+```yaml
 !SET
 - ...
 - ...
 ```
 
-_Nápověda: Pro určení počtu položek v sadě použijte `!COUNT`._
+!!! hint "Nápověda"
 
-
-### Příklady
+    Pro určení počtu položek v sadě použijte `!COUNT`.
 
 Existuje několik způsobů, jak lze v jazyce SP-Lang zadat množinu:
-```yaml
 
-!SET
-- "One"
-- "Dva"
-- "Three"
-- "Four"
-- "Five"
-```
+!!! example "Příklad"
 
+    ```yaml
+    !SET
+    - "One"
+    - "Dva"
+    - "Three"
+    - "Four"
+    - "Five"
+    ```
 
-[Neuspořádaná množina YAML](https://yaml.org/spec/1.2.2/#example-unordered-sets):
-```yaml
+!!! example "Příklad"
+    [Neuspořádaná množina YAML](https://yaml.org/spec/1.2.2/#example-unordered-sets):
 
-!!set
-? Žluté vepřové maso
-? Růžová tráva
-? Bílý sníh
-```
+    ```yaml
+    !!set
+    ? Žluté vepřové maso
+    ? Růžová tráva
+    ? Bílý sníh
+    ```
 
+!!! example "Příklad"
 
-Konzistentní sada pomocí [YAML flow sequences](https://yaml.org/spec/1.2.2/#741-flow-sequences):
-```yaml
+    Kompaktní zápis množiny pomocí [YAML flow sequences](https://yaml.org/spec/1.2.2/#741-flow-sequences):
 
-!SET ["One", "Two", "Three", "Four", "Five"]
-```
+    ```yaml
+    !SET ["One", "Two", "Three", "Four", "Five"]
+    ```
 
+!!! example "Příklad"
+    Formulář pro mapování:
 
-Formulář pro mapování:
-```yaml
-
-!SET
-with:
-  - "One"
-  - "Two"
-  - "Three"
-  - "Four"
-  - "Pět"
-```
+    ```yaml
+    !SET
+    with:
+    - "One"
+    - "Two"
+    - "Three"
+    - "Four"
+    - "Five"
+    ```
 
 
 --- 
@@ -80,27 +82,27 @@ with:
 Typ: _Mapping_.
 
 Synopsis:
-```yaml
 
+```yaml
 !IN
 what: <item>
-kde: <set>
+where: <set>
 ```
 
-Zkontrolujte, zda je `položka` přítomna v `setu`.
+Zkontroluje, zda je `item` přítomna v `set`.
 
-Výraz `!IN` je popsán v kapitole "Testy".
+Výraz `!IN` je popsán v kapitole [Porovnávací výrazy](../comparisons/#in-test-vyskytu).
 
-### Příklad
-```yaml
+!!! example "Příklad"
 
-!IN
-what: 3
-kde:
-  !SET
-  with:
-    - 1
-    - 2
-    - 5
-    - 8 
-```
+    ```yaml
+    !IN
+    what: 3
+    where:
+      !SET
+      with:
+        - 1
+        - 2
+        - 5
+        - 8 
+    ```

--- a/cs/docs/expressions/set.md
+++ b/cs/docs/expressions/set.md
@@ -18,7 +18,7 @@ Množina je nejvhodnější pro testování hodnoty příslušnosti spíše než
 
 Typ:  _Implicitní posloupnost_, _Mapování_.
 
-### Synopsis
+Synopsis:
 ```yaml
 
 !SET
@@ -79,7 +79,7 @@ with:
 
 Typ: _Mapping_.
 
-### Synopsis
+Synopsis:
 ```yaml
 
 !IN

--- a/cs/docs/expressions/set.md
+++ b/cs/docs/expressions/set.md
@@ -18,7 +18,7 @@ Množina je nejvhodnější pro testování hodnoty příslušnosti spíše než
 
 Typ:  _Implicitní posloupnost_, _Mapování_.
 
-### Synopse
+### Synopsis
 ```yaml
 
 !SET
@@ -64,7 +64,7 @@ Formulář pro mapování:
 ```yaml
 
 !SET
-s:
+with:
   - "One"
   - "Two"
   - "Three"
@@ -79,11 +79,11 @@ s:
 
 Typ: _Mapping_.
 
-### Synopse
+### Synopsis
 ```yaml
 
 !IN
-co: <item>
+what: <item>
 kde: <set>
 ```
 
@@ -95,7 +95,7 @@ Výraz `!IN` je popsán v kapitole "Testy".
 ```yaml
 
 !IN
-co: 3
+what: 3
 kde:
   !SET
   with:

--- a/cs/docs/expressions/set.md
+++ b/cs/docs/expressions/set.md
@@ -1,6 +1,6 @@
 ---
 git_commit_hash: b55fa3f
-title: Sada
+title: Množinové
 ---
 
 # Nastavení výrazu

--- a/cs/docs/expressions/string.md
+++ b/cs/docs/expressions/string.md
@@ -1,76 +1,76 @@
 ---
 git_commit_hash: b55fa3f
-title: Řetězcové
+title: Řetězce
 ---
 
-# Řetězcové výrazy
+# Výrazy pro řetězce
 
 
 ---
 
-## `!IN`: Test, zda řetězec obsahuje podřetězec 
+## `!IN`: Testuje, zda řetězec obsahuje podřetězec 
 
-Výraz `!IN` slouží ke kontrole, zda řetězec `what` existuje v řetězci `where`, nebo ne.
+Výraz `!IN` slouží ke kontrole, zda řetězec `what` je podřetězcem `where`, nebo ne.
 
-Typ: Typ: _Mapování_.
+Typ: _Mapping_.
 
 Synopsis:
-```yaml
 
+```yaml
 !IN
 what: <...>
-kde: <...>
+where: <...>
 ```
 
-V opačném případě se vyhodnotí jako `true`, pokud najde podřetězec `what` v řetězci `where`, a false.
+Pokud najde podřetězec `what` v řetězci `where`, vyhodnotí se jako `true`, v opačném případě jako `false`.
 
 
-### Příklad
-```yaml
+!!! example "Příklad"
 
-!IN
-what: "Willy"
-kde: "John Willy Boo"
-```
+    ```yaml
+    !IN
+    what: "Willy"
+    kde: "John Willy Boo"
+    ```
 
-Zkontroluje přítomnost podřetězce "Willy" v hodnotě `where`. Vrací hodnotu `true`.
+    Zkontroluje přítomnost podřetězce "Willy" v hodnotě `where`. Vrátí hodnotu `true`.
 
 
-### Víceřetězcová varianta
+### Varianta pro více řetězců
 
 Existuje speciální varianta operátoru `!IN` pro kontrolu, zda je některý z řetězců uvedených v hodnotě `what` (v tomto případě seznam) v řetězci. Jedná se o efektivní, optimalizovanou implementaci víceřetězcového matcheru.
-```yaml
 
+```yaml
 !IN
 what:
   - "John"
   - "Boo"
   - "ly"
-kde: "John Willy Boo"
+where: "John Willy Boo"
 ```
 
 Jedná se o velmi efektivní způsob kontroly, zda je v řetězci `where` přítomen alespoň jeden podřetězec.
-Poskytuje [Incremental String Matching](http://se.ethz.ch/~meyer/publications/string/string_matching.pdf) algoritmus pro rychlé porovnávání vzorů v řetězcích.
+Podporuje [Incremental String Matching](http://se.ethz.ch/~meyer/publications/string/string_matching.pdf) algoritmus pro rychlé porovnávání vzorů v řetězcích.
 Díky tomu je ideálním nástrojem pro komplexní filtrování jako samostatný bit nebo jako optimalizační technika.
 
-Příklad optimalizace `!REGEX` pomocí víceřetězcového `!IN`:
-```yaml
+!!! example "Příklad optimalizace `!REGEX` pomocí víceřetězcového `!IN`:"
 
-!AND
-- !IN
-  kde: !ARG zpráva
-  what:
-  - "msgbox"
-  - "showmod"
-  - "showhelp"
-  - "prompt"
-  - "write"
-  - "test"
-  - "mail.com"
-- !REGEX
-  what: !ARG zpráva
-  regex: "(msgbox|showmod(?:al|eless)dialog|showhelp|prompt|write)|(test[0-9])|([a-z]@mail\.com)
-```
+    ```yaml
+        !AND
+        - !IN
+          where: !ARG message
+          what:
+          - "msgbox"
+          - "showmod"
+          - "showhelp"
+          - "prompt"
+          - "write"
+          - "test"
+          - "mail.com"
+        - !REGEX
+          what: !ARG message
+          regex: "(msgbox|showmod(?:al|eless)dialog|showhelp|prompt|write)|(test[0-9])|([a-z]@mail\.com)
+    ```
 
 Tento přístup se doporučuje z aplikací v proudech, kde je třeba filtrovat rozsáhlé množství dat s předpokladem, že pouze menší část dat odpovídá vzorům.
 Přímá aplikace výrazu `!REGEX` výrazně zpomalí zpracování, protože se jedná o složitý regulární výraz.
@@ -86,88 +86,81 @@ Z tohoto důvodu musí být `!IN` dokonalou nadmnožinou `!REGEX`, to znamená:
 
 ---
 
-## `!STARTSWITH`: Otestujte, zda řetězec začíná předponou 
+## `!STARTSWITH`: Otestuje, zda řetězec začíná předponou 
 
 Vrací hodnotu `true`, pokud řetězec `what` začíná předponou `prefix`.
 
-Typ: _Mapování_
+Typ:  _Mapping_
 
 Synopsis:
-```yaml
 
+```yaml
 !STARTSWITH
 what: <...>
 prefix: <...>
 ```
 
 
-### Příklad
-```yaml
+!!! example "Příklad"
 
-!STARTSWITH
-what: "FooBar"
-prefix: "Foo"
-```
+    ```yaml
+    !STARTSWITH
+    what: "FooBar"
+    prefix: "Foo"
+    ```
 
 ### Víceřetězcová varianta
 
 
-!!! warning "Probíhající práce"
+!!! warning "Work in progress"
 
-	
-	
 	Zatím neimplementováno.
-	
-	
-```yaml
 
+
+```yaml
 !STARTSWITH
 what: <...>
-prefix: ]: [<prefix1>, <prefix2>, ...]
+prefix: [<prefix1>, <prefix2>, ...]
 ```
 
 Ve víceřetězcové variantě je definován seznam řetězců.
-Výraz se vyhodnotí jako `pravdivý`, pokud alespoň jeden prefixový řetězec odpovídá začátku řetězce `co`.
+Výraz se vyhodnotí jako `true`, pokud alespoň jeden prefixový řetězec odpovídá začátku řetězce `what`.
 
 
 ---
 
-## `!ENDSWITH`: Testuje, zda řetězec končí postfixem 
+## `!ENDSWITH`: Testuje, zda řetězec končí příponou
 
-Vrací hodnotu `true`, pokud řetězec `what` končí znakem `postfix`.
+Vrací hodnotu `true`, pokud řetězec `what` končí příponou `postfix`.
 
-Typ: _Mapování_
-
+Typ: _Mapping_
 
 Synopsis:
-```yaml
 
+```yaml
 !ENDSWITH
 what: <...>
 postfix: <...>
 ```
 
 
-### Příklad
-```yaml
+!!! example "Příklad"
 
-!ENDSWITH
-what: "autoexec.bat"
-postfix: "bat"
-```
+    ```yaml
+    !ENDSWITH
+    what: "autoexec.bat"
+    postfix: "bat"
+    ```
 
 ### Víceřetězcová varianta
 
 
-!!! warning "Probíhající práce"
+!!! warning "Work in progress"
 
-	
-	
 	Zatím neimplementováno.
-	
-	
-```yaml
 
+
+```yaml
 !ENDSWITH
 what: <...>
 postfix: [<postfix1>, <postfix2>, ...]
@@ -179,16 +172,16 @@ Výraz se vyhodnotí jako `true`, pokud alespoň jeden postfixový řetězec odp
 
 ---
 
-## `!SUBSTRING`: Výpis části řetězce 
+## `!SUBSTRING`: Extrahuje část řetězce 
 
 Vrátí část řetězce `what` mezi indexy `from` a `to`.
 
-Typ: Typ: _Mapování_
+Typ: _Mapping_
 
 
 Synopsis:
-```yaml
 
+```yaml
 !SUBSTRING
 what: <...>
 od: <...>
@@ -197,114 +190,111 @@ do: <...>
 
 !!! info
 
-	
-	
-	
-	První znak řetězce se nachází na pozici `from=0`.
-	
-	
+    První znak řetězce se nachází na pozici `from=0`.
 
-### Příklad
-```yaml
 
-!SUBSTRING
-what: "FooBar"
-from: 1
-do: 3
-```
+!!! example "Příklad"
 
-Vrací `oo`.
+    ```yaml
+    !SUBSTRING
+    what: "FooBar"
+    from: 1
+    do: 3
+    ```
+
+    Vrací `oo`.
 
 ---
 
 ## `!LOWER`: Převede řetězec na malá písmena 
 
-Typ: _Mapování_
+Typ: _Mapping_
 
 
 Synopsis:
-```yaml
 
+```yaml
 !LOWER
 what: <...>
 ```
 
 
-### Příklad
-```yaml
+!!! example "Příklad"
 
-!LOWER
-what: "FooBar"
-```
+    ```yaml
+    !LOWER
+    what: "FooBar"
+    ```
 
-Vrací `foobar`.
+    Vrací `foobar`.
 
 
 ---
 
-## `!UPPER`: Transformovat řetězec na velká písmena 
+## `!UPPER`: Převede řetězec na velká písmena 
 
-Typ: _Mapování_
+Typ: _Mapping_
 
 Synopsis:
-```yaml
 
+```yaml
 !UPPER
 what: <...>
 ```
 
 
-### Příklad
-```yaml
+!!! example "Příklad"
 
-!UPPER
-what: "FooBar"
-```
+    ```yaml
+    !UPPER
+    what: "FooBar"
+    ```
 
-Vrací `FOOBAR`.
+    Vrací `FOOBAR`.
 
 ---
 
 ## `!CUT`: Vyjmout část řetězce 
 
-Rozřízne řetězec oddělovačem a vrátí část identifikovanou indexem `pole` (začíná 0).
+Rozdělí řetězec oddělovačem a vrátí část identifikovanou indexem `field` (začíná 0).
 
-Typ: _Mapování_
+Typ: _Mapping_
 
 Synopsis:
-```yaml
 
+```yaml
 !CUT
 what: <string>
-oddělovač: <string>
-pole: <int>
+delimiter: <string>
+field: <int>
 ```
 
-Řetězec argumentu `hodnota` bude rozdělen pomocí argumentu `oddělovač`.
-Argument `pole` určuje počet rozdělených řetězců, které se mají vrátit, počínaje 0.  
-Pokud je uveden záporný údaj `pole`, pak se pole bere od konce řetězce, například -2 znamená předposlední podřetězec.
+Řetězec argumentu `value` bude rozdělen pomocí argumentu `delimiter`.
+Argument `field` určuje počet rozdělených řetězců, které se mají vrátit, počínaje 0.  
+Pokud je uveden záporný údaj `field`, pak se pole bere od konce řetězce, například -2 znamená předposlední podřetězec.
 
 
-### Příklad
-```yaml
+!!! example "Příklad"
 
-!CUT
-what: "Jablko,Pomeranč,Meloun,Citrus,Hruška"
-oddělovač: ","
-pole: 2
-```
+    ```yaml
+    !CUT
+    what: "Apple,Orange,Melon,Citrus,Pear"
+    delimiter: ","
+    field: 2
+    ```
 
-Vrátí hodnotu "Melon".
+    Vrátí hodnotu "Melon".
 
-```yaml
+!!! example "Příklad"
 
-!CUT
-what: "Apple,Orange,Melon,Citrus,Pear"
-oddělovač: ","
-pole: -2
-```
+    ```yaml
+    !CUT
+    what: "Apple,Orange,Melon,Citrus,Pear"
+    delimiter: ","
+    field: -2
+    ```
 
-Vrátí hodnotu "Citrus".
+    Vrátí hodnotu "Citrus".
 
   
 ---
@@ -313,11 +303,11 @@ Vrátí hodnotu "Citrus".
 
 Rozdělí řetězec na seznam řetězců.
 
-Typ: _Mapování_
+Typ: _Mapping_
 
 Synopsis:
-```yaml
 
+```yaml
 !SPLIT
 what: <string>
 oddělovač: <string>
@@ -328,44 +318,63 @@ maxsplit: <number>
 Nepovinný argument `maxsplit` určuje, kolik rozdělení se má provést.
 
 
-### Příklad
-```yaml
+!!! example "Příklad"
 
-!SPLIT
-what: "hello,world"
-delimiter: ","
-```
+    ```yaml
+    !SPLIT
+    what: "hello,world"
+    delimiter: ","
+    ```
 
-Výsledkem je seznam: `["hello", "world"]`.
+    Výsledkem je seznam: `["hello", "world"]`.
 
 ---
 
-## `!JOIN`: Spojení seznamu řetězců 
+## `!RSPLIT`: Rozdělí řetězec do seznamu zprava
 
-Typ: _Mapování_
+Rozdělí řetězec zprava (od konce řetězce) do seznamu řetězců.
+
+Type: _Mapping_
 
 Synopsis:
-```yaml
 
+```yaml
+!RSPLIT
+what: <string>
+delimiter: <string>
+maxsplit: <number>
+```
+
+Argument `what` se rozdělí podle `delimeter`. Nepovinný argument `maxsplit` určuje, kolik rozdělení se má provést.
+
+---
+
+## `!JOIN`: Spojí seznam řetězců 
+
+Typ: _Mapping_
+
+Synopsis:
+
+```yaml
 !JOIN
-položek:
+items:
   - <...>
   - <...>
 delimiter: <string>
 miss: ''
 ```
 
-Výchozím `oddělovačem` je mezera (" ").
+Výchozí `delimiter` je mezera (" ").
 
 Pokud je položka `None`, použije se hodnota parametru `miss`, ve výchozím nastavení je to prázdný řetězec.
 Pokud je `miss` `None` a některá z položek `items` je `None`, výsledkem celého spojení je `None`.
 
-### Příklad
-```yaml
+!!! example "Příklad"
 
-!JOIN
-items:
-  - "Foo"
-  - "Bar"
-oddělovač: ','
-```
+    ```yaml
+    !JOIN
+    items:
+      - "Foo"
+      - "Bar"
+    delimiter: ','
+    ```

--- a/cs/docs/expressions/string.md
+++ b/cs/docs/expressions/string.md
@@ -1,6 +1,6 @@
 ---
 git_commit_hash: b55fa3f
-title: Řetězec
+title: Řetězcové
 ---
 
 # Řetězcové výrazy

--- a/cs/docs/expressions/string.md
+++ b/cs/docs/expressions/string.md
@@ -14,11 +14,11 @@ Výraz `!IN` slouží ke kontrole, zda řetězec `what` existuje v řetězci `wh
 
 Typ: Typ: _Mapování_.
 
-### Synopse
+### Synopsis
 ```yaml
 
 !IN
-co: <...>
+what: <...>
 kde: <...>
 ```
 
@@ -29,7 +29,7 @@ V opačném případě se vyhodnotí jako `true`, pokud najde podřetězec `what
 ```yaml
 
 !IN
-co: "Willy"
+what: "Willy"
 kde: "John Willy Boo"
 ```
 
@@ -59,7 +59,7 @@ Příklad optimalizace `!REGEX` pomocí víceřetězcového `!IN`:
 !AND
 - !IN
   kde: !ARG zpráva
-  co:
+  what:
   - "msgbox"
   - "showmod"
   - "showhelp"
@@ -68,7 +68,7 @@ Příklad optimalizace `!REGEX` pomocí víceřetězcového `!IN`:
   - "test"
   - "mail.com"
 - !REGEX
-  co: !ARG zpráva
+  what: !ARG zpráva
   regex: "(msgbox|showmod(?:al|eless)dialog|showhelp|prompt|write)|(test[0-9])|([a-z]@mail\.com)
 ```
 
@@ -92,11 +92,11 @@ Vrací hodnotu `true`, pokud řetězec `what` začíná předponou `prefix`.
 
 Typ: _Mapování_
 
-### Synopse
+### Synopsis
 ```yaml
 
 !STARTSWITH
-co: <...>
+what: <...>
 prefix: <...>
 ```
 
@@ -105,7 +105,7 @@ prefix: <...>
 ```yaml
 
 !STARTSWITH
-co: "FooBar"
+what: "FooBar"
 prefix: "Foo"
 ```
 
@@ -122,7 +122,7 @@ prefix: "Foo"
 ```yaml
 
 !STARTSWITH
-co: <...>
+what: <...>
 prefix: ]: [<prefix1>, <prefix2>, ...]
 ```
 
@@ -139,11 +139,11 @@ Vrací hodnotu `true`, pokud řetězec `what` končí znakem `postfix`.
 Typ: _Mapování_
 
 
-### Synopse
+### Synopsis
 ```yaml
 
 !ENDSWITH
-co: <...>
+what: <...>
 postfix: <...>
 ```
 
@@ -152,7 +152,7 @@ postfix: <...>
 ```yaml
 
 !ENDSWITH
-co: "autoexec.bat"
+what: "autoexec.bat"
 postfix: "bat"
 ```
 
@@ -169,7 +169,7 @@ postfix: "bat"
 ```yaml
 
 !ENDSWITH
-co: <...>
+what: <...>
 postfix: [<postfix1>, <postfix2>, ...]
 ```
 
@@ -186,11 +186,11 @@ Vrátí část řetězce `what` mezi indexy `from` a `to`.
 Typ: Typ: _Mapování_
 
 
-### Synopse
+### Synopsis
 ```yaml
 
 !SUBSTRING
-co: <...>
+what: <...>
 od: <...>
 do: <...>
 ```
@@ -222,11 +222,11 @@ Vrací `oo`.
 Typ: _Mapování_
 
 
-### Synopse
+### Synopsis
 ```yaml
 
 !LOWER
-co: <...>
+what: <...>
 ```
 
 
@@ -234,7 +234,7 @@ co: <...>
 ```yaml
 
 !LOWER
-co: "FooBar"
+what: "FooBar"
 ```
 
 Vrací `foobar`.
@@ -246,11 +246,11 @@ Vrací `foobar`.
 
 Typ: _Mapování_
 
-### Synopse
+### Synopsis
 ```yaml
 
 !UPPER
-co: <...>
+what: <...>
 ```
 
 
@@ -258,7 +258,7 @@ co: <...>
 ```yaml
 
 !UPPER
-co: "FooBar"
+what: "FooBar"
 ```
 
 Vrací `FOOBAR`.
@@ -271,11 +271,11 @@ Rozřízne řetězec oddělovačem a vrátí část identifikovanou indexem `pol
 
 Typ: _Mapování_
 
-### Synopse
+### Synopsis
 ```yaml
 
 !CUT
-co: <string>
+what: <string>
 oddělovač: <string>
 pole: <int>
 ```
@@ -289,7 +289,7 @@ Pokud je uveden záporný údaj `pole`, pak se pole bere od konce řetězce, nap
 ```yaml
 
 !CUT
-co: "Jablko,Pomeranč,Meloun,Citrus,Hruška"
+what: "Jablko,Pomeranč,Meloun,Citrus,Hruška"
 oddělovač: ","
 pole: 2
 ```
@@ -299,7 +299,7 @@ Vrátí hodnotu "Melon".
 ```yaml
 
 !CUT
-co: "Apple,Orange,Melon,Citrus,Pear"
+what: "Apple,Orange,Melon,Citrus,Pear"
 oddělovač: ","
 pole: -2
 ```
@@ -315,11 +315,11 @@ Rozdělí řetězec na seznam řetězců.
 
 Typ: _Mapování_
 
-### Synopse
+### Synopsis
 ```yaml
 
 !SPLIT
-co: <string>
+what: <string>
 oddělovač: <string>
 maxsplit: <number>
 ```
@@ -344,7 +344,7 @@ Výsledkem je seznam: `["hello", "world"]`.
 
 Typ: _Mapování_
 
-### Synopse
+### Synopsis
 ```yaml
 
 !JOIN

--- a/cs/docs/expressions/string.md
+++ b/cs/docs/expressions/string.md
@@ -14,7 +14,7 @@ Výraz `!IN` slouží ke kontrole, zda řetězec `what` existuje v řetězci `wh
 
 Typ: Typ: _Mapování_.
 
-### Synopsis
+Synopsis:
 ```yaml
 
 !IN
@@ -92,7 +92,7 @@ Vrací hodnotu `true`, pokud řetězec `what` začíná předponou `prefix`.
 
 Typ: _Mapování_
 
-### Synopsis
+Synopsis:
 ```yaml
 
 !STARTSWITH
@@ -139,7 +139,7 @@ Vrací hodnotu `true`, pokud řetězec `what` končí znakem `postfix`.
 Typ: _Mapování_
 
 
-### Synopsis
+Synopsis:
 ```yaml
 
 !ENDSWITH
@@ -186,7 +186,7 @@ Vrátí část řetězce `what` mezi indexy `from` a `to`.
 Typ: Typ: _Mapování_
 
 
-### Synopsis
+Synopsis:
 ```yaml
 
 !SUBSTRING
@@ -222,7 +222,7 @@ Vrací `oo`.
 Typ: _Mapování_
 
 
-### Synopsis
+Synopsis:
 ```yaml
 
 !LOWER
@@ -246,7 +246,7 @@ Vrací `foobar`.
 
 Typ: _Mapování_
 
-### Synopsis
+Synopsis:
 ```yaml
 
 !UPPER
@@ -271,7 +271,7 @@ Rozřízne řetězec oddělovačem a vrátí část identifikovanou indexem `pol
 
 Typ: _Mapování_
 
-### Synopsis
+Synopsis:
 ```yaml
 
 !CUT
@@ -315,7 +315,7 @@ Rozdělí řetězec na seznam řetězců.
 
 Typ: _Mapování_
 
-### Synopsis
+Synopsis:
 ```yaml
 
 !SPLIT
@@ -344,7 +344,7 @@ Výsledkem je seznam: `["hello", "world"]`.
 
 Typ: _Mapování_
 
-### Synopsis
+Synopsis:
 ```yaml
 
 !JOIN

--- a/cs/docs/expressions/tuple.md
+++ b/cs/docs/expressions/tuple.md
@@ -15,11 +15,11 @@ Tuple je kolekce položek, případně různých typů.
 
 Typ:  _Mapping_.
 
-### Synopse
+### Synopsis
 ```yaml
 
 !TUPLE
-s:
+with:
   - ...
   - ...
   ...
@@ -33,7 +33,7 @@ Pořadí položek je zachováno.
 ```yaml
 
 !TUPLE
-s:
+with:
   - John Doe
   - 37
   - 175.4
@@ -61,7 +61,7 @@ Vynucení specifického typu položky:
 ```yaml
 
 !TUPLE
-s:
+with:
   - John Doe
   - !!ui8 37
   - 175.4
@@ -76,11 +76,11 @@ Položka č. 1 bude mít typ `ui8`.
 
 Typ: _Mapping_.
 
-### Synopse
+### Synopsis
 ```yaml
 
 !GET
-co: <index of the item>
+what: <index of the item>
 z: <tuple>
 ```
 
@@ -97,7 +97,7 @@ Pokud je `what` mimo hranice seznamu, příkaz se vrátí s chybou.
 what: 1
 from:
   !TUPLE
-  s:
+  with:
     - Doe:: John Doe
     - 32
     - 127.5
@@ -110,7 +110,7 @@ Použití _záporného indexu_ položek:
 ```yaml
 
 !GET
-co: -1
+what: -1
 od:
   !TUPLE
   with:

--- a/cs/docs/expressions/tuple.md
+++ b/cs/docs/expressions/tuple.md
@@ -3,11 +3,11 @@ git_commit_hash: b55fa3f
 title: Tuple
 ---
 
-# Tuplové výrazy
+# Výrazy pro tuple
 
 
-Tuple je jednou ze základních datových struktur, které SP-Lang nabízí.
-Tuple je kolekce položek, případně různých typů.
+Tuple (do češtiny přeložitelné asi jako 'pevný seznam') je jednou ze základních datových struktur, které SP-Lang nabízí.
+Tuple je kolekce položek, které mohou mít různé typy.
 
 --- 
 
@@ -16,8 +16,8 @@ Tuple je kolekce položek, případně různých typů.
 Typ:  _Mapping_.
 
 Synopsis:
-```yaml
 
+```yaml
 !TUPLE
 with:
   - ...
@@ -29,94 +29,98 @@ Počet položek v tuple není omezen.
 Pořadí položek je zachováno.
 
 
-### Příklady
-```yaml
+!!! example "Příklad"
 
-!TUPLE
-with:
-  - John Doe
-  - 37
-  - 175.4
-```
+    ```yaml
+    !TUPLE
+    with:
+      - John Doe
+      - 37
+      - 175.4
+    ```
 
+!!! example "Příklad"
 
-Použití zápisu `!!tuple`:
-```yaml
+    Použití zápisu `!!tuple`:
 
-!!tuple
-- 1
-- a
-- 1.2
-```
+    ```yaml
+    !!tuple
+    - 1
+    - a
+    - 1.2
+    ```
 
+!!! example "Příklad"
 
-Ještě stručnější verze `!!tuple` s použitím syntaxe flow:
-```yaml
+    Ještě stručnější verze `!!tuple` s použitím flow syntaxe:
 
-!!tuple ['John Doe', 37, 175.4]
-```
+    ```yaml
+    !!tuple ['John Doe', 37, 175.4]
+    ```
 
+!!! example "Příklad"
 
-Vynucení specifického typu položky:
-```yaml
+    Vynucení specifického typu položky:
 
-!TUPLE
-with:
-  - John Doe
-  - !!ui8 37
-  - 175.4
-```
+    ```yaml
+    !TUPLE
+    with:
+      - John Doe
+      - !!ui8 37
+      - 175.4
+    ```
 
-Položka č. 1 bude mít typ `ui8`.
+    Položka #1 bude mít typ `ui8`.
 
 
 --- 
 
-## `!GET`: Získat položku z tuple 
+## `!GET`: Získá položku z tuple 
 
 Typ: _Mapping_.
 
 Synopsis:
-```yaml
 
+```yaml
 !GET
 what: <index of the item>
-z: <tuple>
+from: <tuple>
 ```
 
-Je to celé číslo, které představuje _index_ v tuplu.
+`what` je celé číslo, které představuje _index_ v tuple.
 `what` může být záporné, v takovém případě určuje položku od konce seznamu.
 Položky jsou indexovány od 0, to znamená, že první položka v seznamu má index 0.
 Pokud je `what` mimo hranice seznamu, příkaz se vrátí s chybou.
 
 
-### Příklady
-```yaml
+!!! example "Příklad"
 
-!GET
-what: 1
-from:
-  !TUPLE
-  with:
-    - Doe:: John Doe
-    - 32
-    - 127.5
-```
+    ```yaml
+    !GET
+    what: 1
+    from:
+      !TUPLE
+      with:
+        - Doe:: John Doe
+        - 32
+        - 127.5
+    ```
 
-Vrací `32`.
+    Vrací `32`.
 
+!!! example "Příklad"
 
-Použití _záporného indexu_ položek:
-```yaml
+    Použití _záporného indexu_ položek:
 
-!GET
-what: -1
-od:
-  !TUPLE
-  with:
-    - John Doe
-    - 32
-    - 127.5
-```
+    ```yaml
+    !GET
+    what: -1
+    from:
+      !TUPLE
+      with:
+        - John Doe
+        - 32
+        - 127.5
+    ```
 
-Vrací `127,5`.
+    Vrací `127,5`.

--- a/cs/docs/expressions/tuple.md
+++ b/cs/docs/expressions/tuple.md
@@ -15,7 +15,7 @@ Tuple je kolekce položek, případně různých typů.
 
 Typ:  _Mapping_.
 
-### Synopsis
+Synopsis:
 ```yaml
 
 !TUPLE
@@ -76,7 +76,7 @@ Položka č. 1 bude mít typ `ui8`.
 
 Typ: _Mapping_.
 
-### Synopsis
+Synopsis:
 ```yaml
 
 !GET

--- a/cs/docs/expressions/utility.md
+++ b/cs/docs/expressions/utility.md
@@ -12,7 +12,7 @@ title: Pomocné
 
 Typ: _Mapping_.
 
-### Synopsis
+Synopsis:
 ```yaml
 
 !CAST
@@ -46,7 +46,7 @@ Jedná se o explicitní převod řetězce na číslo s pohyblivou řádovou čá
 
 Typ: _Mapping_.
 
-### Synopsis
+Synopsis:
 ```yaml
 
 !HASH

--- a/cs/docs/expressions/utility.md
+++ b/cs/docs/expressions/utility.md
@@ -3,66 +3,66 @@ git_commit_hash: b55fa3f
 title: Pomocné
 ---
 
-# Užitkové výrazy
+# Pomocné výrazy
 
 
 ---
 
-## `!CAST`: Převést typ argumentu na jiný 
+## `!CAST`: Převádí typ argumentu na jiný 
 
 Typ: _Mapping_.
 
 Synopsis:
-```yaml
 
+```yaml
 !CAST
 what: <input>
 typ: <type>
 ```
 
-Explicitně převést typ `what` na typ `type`.
+Explicitně převádí typ `what` na typ `type`.
 
 SP-Lang automaticky převádí typy argumentů, takže uživatel nemusí na typy vůbec myslet.
-Tato funkce se nazývá *implicitní odlévání*.
+Tato funkce se nazývá *implicit casting*.
 
 V případě potřeby explicitní konverze typu použijte výraz `!CAST`.
 Jedná se o velmi mocnou metodu, která dělá hodně těžkou práci.
 
 Další podrobnosti najdete v kapitole o [typech](../../language/types).
 
-### Příklad
-```yaml
+!!! example "Příklad"
 
-!CAST
-what: "10.3"
-type: fp64
-```
+	```yaml
+	!CAST
+	what: "10.3"
+	type: fp64
+	```
 
-Jedná se o explicitní převod řetězce na číslo s pohyblivou řádovou čárkou.
+	Jedná se o explicitní převod řetězce na číslo s desetinnou čárkou.
 
 ---
 
-## `!HASH`: Vypočítat digest 
+## `!HASH`: Vypočítá digest
 
 Typ: _Mapping_.
 
 Synopsis:
-```yaml
 
+```yaml
 !HASH
 what: <input>
 seed: <integer>
 typ: <type of hash>
 ```
 
-Vypočítat hash pro hodnotu `what`.
+Vypočítá hash pro hodnotu `what`.
 
 `seed` určuje počáteční hash seed.
 
 `type` určuje hašovací funkci, výchozí hodnota je `XXH64`.
 
 
-#### Podporované hašovací funkce
+### Podporované hašovací funkce
 
 * `XXH64`: xxHash, 64bitový, nekryptografický, extrémně rychlý hashovací algoritmus.
 * `XXH3`: xxHash, 64bit, nekryptografický, optimalizovaný pro malé vstupy
@@ -70,20 +70,20 @@ Vypočítat hash pro hodnotu `what`.
 Více informací o xxHash naleznete na adrese [xxhash.com](http://www.xxhash.com/).
 
 
-### Příklad
-```yaml
+!!! example "Příklad"
 
-!HASH
-what: "Hello world!"
-seed: 5
-```
+	```yaml
+	!HASH
+	what: "Hello world!"
+	seed: 5
+	```
 
 
 ---
 
-## `!DEBUG`: Ladění výrazu 
+## `!DEBUG`: Ladění výrazů 
 
 Vypíše obsah vstupu a na výstupu předá nezměněnou hodnotu.
 
-Typ: _Mapování_.
+Typ: _Mapping_.
 

--- a/cs/docs/expressions/utility.md
+++ b/cs/docs/expressions/utility.md
@@ -12,11 +12,11 @@ title: Pomocné
 
 Typ: _Mapping_.
 
-### Synopse
+### Synopsis
 ```yaml
 
 !CAST
-co: <input>
+what: <input>
 typ: <type>
 ```
 
@@ -34,7 +34,7 @@ Další podrobnosti najdete v kapitole o [typech](../../language/types).
 ```yaml
 
 !CAST
-co: "10.3"
+what: "10.3"
 type: fp64
 ```
 
@@ -46,11 +46,11 @@ Jedná se o explicitní převod řetězce na číslo s pohyblivou řádovou čá
 
 Typ: _Mapping_.
 
-### Synopse
+### Synopsis
 ```yaml
 
 !HASH
-co: <input>
+what: <input>
 seed: <integer>
 typ: <type of hash>
 ```
@@ -74,7 +74,7 @@ Více informací o xxHash naleznete na adrese [xxhash.com](http://www.xxhash.com
 ```yaml
 
 !HASH
-co: "Hello world!"
+what: "Hello world!"
 seed: 5
 ```
 

--- a/cs/docs/expressions/utility.md
+++ b/cs/docs/expressions/utility.md
@@ -1,6 +1,6 @@
 ---
 git_commit_hash: b55fa3f
-title: Utility
+title: Pomocné
 ---
 
 # Užitkové výrazy

--- a/cs/docs/index.md
+++ b/cs/docs/index.md
@@ -17,8 +17,6 @@ Doufáme, že vám tato dokumentace poskytne všechny informace, které potřebu
 
 !!! quote "Vyrobeno s :octicons-heart-fill-24:{ .heart } v TeskaLabs"
 
-	
-	
 	SP-Lang je technologie vytvářená ve společnosti [TeskaLabs](https://www.teskalabs.com).  
 	
 
@@ -47,7 +45,6 @@ Z tohoto důvodu je SP-Lang přirozeným kandidátem na nákladově efektivní z
 
 
 !!! example "Stejný příklad ve vizuální podobě SP-Langu"
-
 
 	<img src="visual-hello-world.jpg" alt="Visual Hello world in SP-Lang" style="width: 197px;" />
 

--- a/cs/docs/index.md
+++ b/cs/docs/index.md
@@ -3,23 +3,23 @@ git_commit_hash: b55fa3f
 title: Vítejte!
 ---
 
-# Dokumentace SP-Lang
+# Dokumentace SP-Langu
 
-Vítejte v dokumentaci k SP-Lang. SP-Lang je zkratka pro _Stream Processing Language_.
+Vítejte u dokumentace SP-Langu. SP-Lang je zkratka pro _Stream Processing Language_.
 SP-Lang je navržen jako intuitivní a snadno použitelný jazyk i pro lidi, kteří nemají zkušenosti s programováním.
 Snažíme se, aby jeho používání bylo stejně jednoduché jako používání maker v tabulkovém procesoru nebo jazyka SQL, což vám umožní provádět výkonné úlohy zpracování dat s minimálním úsilím.
 
 Hlavním cílem jazyka SP-Lang je, aby za vás udělal mnoho těžké práce, takže se můžete soustředit na to, čeho chcete dosáhnout, a ne se starat o detaily, jak to realizovat.
-Tento nízkokódový přístup znamená, že můžete rychle začít pracovat, aniž byste se museli učit spoustu složitých programovacích konceptů.
+Tento nízkoúrovňový přístup vám umožní rychle začít pracovat, aniž byste se museli učit spoustu složitých programovacích konceptů.
 
 Doufáme, že vám tato dokumentace poskytne všechny informace, které potřebujete k tomu, abyste mohli začít pracovat s naším jazykem a začít využívat jeho výkonné možnosti proudového zpracování. Děkujeme, že jste si vybrali náš jazyk, a těšíme se na to, co s ním dokážete!
 
 
-!!! quote "Made with :octicons-heart-fill-24:{ .heart } by TeskaLabs"
+!!! quote "Vyrobeno s :octicons-heart-fill-24:{ .heart } v TeskaLabs"
 
 	
 	
-	SP-Lang je technologie vytvořená ve společnosti [TeskaLabs](https://www.teskalabs.com).  
+	SP-Lang je technologie vytvářená ve společnosti [TeskaLabs](https://www.teskalabs.com).  
 	
 
 <!-- <img src="splang-logo.jpg" alt="SP-lang logo" style="width: 128px;" /> -->
@@ -30,7 +30,7 @@ Doufáme, že vám tato dokumentace poskytne všechny informace, které potřebu
 _SP-Lang_ je [funkcionální jazyk](https://cs.wikipedia.org/wiki/Funkcionální_programování), který používá syntaxi [YAML](https://cs.wikipedia.org/wiki/YAML).
 
 SP-Lang poskytuje velmi vysoký výkon, protože je zkompilován do [strojového kódu](https://cs.wikipedia.org/wiki/Strojový_kód).
-To mu spolu s rozsáhlými optimalizacemi dává výkon ve stejné kategorii jako C, Go nebo Rust; respektive nejvyšší možný výkon.
+To mu spolu s rozsáhlými optimalizacemi dává výkon srovnatelný s jazyky jako jsou C, Go nebo Rust; tedy nejvýše dosažitelný.
 
 Z tohoto důvodu je SP-Lang přirozeným kandidátem na nákladově efektivní zpracování masivních datových toků v cloudu nebo v on-premise aplikacích.
 
@@ -51,7 +51,7 @@ Z tohoto důvodu je SP-Lang přirozeným kandidátem na nákladově efektivní z
 
 	<img src="visual-hello-world.jpg" alt="Visual Hello world in SP-Lang" style="width: 197px;" />
 
-**Vaše první kroky s jazykem SP-Lang začnou v [tutoriálu](výukovém programu).**
+**Pro první seznámení s jazykem SP-Lang vyzkoušejte náš [tutoriál](./tutorial.md).**
 
 ## Vlastnosti jazyka SP-Lang
 

--- a/cs/docs/language/performance.md
+++ b/cs/docs/language/performance.md
@@ -28,7 +28,7 @@ Hodí se např. pro klasifikaci škodlivých adres URL (poskytnutých blokovým 
 
 !IN
   kde: !ARG url
-  co:
+  what:
   - ".000a.biz"
   - ".001edizioni.com"
  < 64 domains in total >

--- a/cs/docs/language/schema.md
+++ b/cs/docs/language/schema.md
@@ -53,7 +53,7 @@ from: !ARG input
 ```yaml
 
 !GET
-co: FieldOne
+what: FieldOne
 from: !ARG input
 ```
 

--- a/cs/docs/language/types.md
+++ b/cs/docs/language/types.md
@@ -371,7 +371,7 @@ Pro změnu typu hodnoty použijte výraz `!CAST`.
 ```yaml
 
 !CAST
-co: 1234
+what: 1234
 typ: fp32
 ```
 

--- a/cs/docs/syntax.md
+++ b/cs/docs/syntax.md
@@ -5,9 +5,7 @@ title: Syntaxe
 
 # Syntaxe jazyka SP
 
-
 !!! info
-
 
 		Syntaxe SP-Lang používá [YAML 1.2](https://yaml.org/spec/1.2)
 
@@ -24,18 +22,18 @@ Komentář je označen indikátorem `#`.
 
 ## Čísla
 
-### Celé číslo
+### Celá čísla
 ```yaml
 
 kanonický zápis: 12345
-kladné desetinné číslo: +12345
-záporné desetinné číslo: -12345
+kladné číslo: +12345
+záporné číslo: -12345
 osmičkový zápis: 0o14
 hexadecimální zápis: 0xC
 ```
 
 
-### Plovoucí čárka
+### Desetinná čísla
 ```yaml
 
 pevný zápis: 1230.15
@@ -60,8 +58,8 @@ unicode: "\u263A"
 control: "\b1998\t1999\t2000\n"
 hexadecimální esc: "\x0d\x0a je \r\n"
 
-singl: ""Nazdar!" zvolal.
-citováno: # Not a ''comment''.
+singl: '"Nazdar!" zvolal.'
+citováno: '# Toto není ''komentář''.'
 ```
 
 Víceřádkové řetězce:
@@ -88,7 +86,7 @@ Doslovný styl (označený `|`) zachovává počáteční mezery.
 Složený styl (označený `>`) odstraňuje případné odsazení YAML.
 
 
-## Booleans
+## Pravdivostní hodnoty (booleans)
 ```yaml
 
 True boolean: true
@@ -102,22 +100,22 @@ Všechny výrazy SP-Lang (alias funkce) začínají na `!`, výrazy SP-Lang jsou
 
 Výrazy mohou být těchto typů:
 
- - _Mapování_
- - _Sequence_
- - _Skalární_
+ - _Mapování_ (_Mapping_)
+ - _Posloupnost_ (_Sequence_)
+ - _Skalár_ (_Scalar_)
 
 
-### Mapovací výraz
+### Mapovací výrazy
 
 Příklad:
 ```yaml
 
 !ENDSWITH
-co: FooBar
+what: FooBar
 postfix: Bar
 ```
 
-Příklad _flow_ formuláře:
+Příklad použití ve formě _flow_ :
 ```yaml
 !ENDSWITH {what: FooBar, postfix: Bar}
 ```
@@ -125,13 +123,11 @@ Příklad _flow_ formuláře:
 
 !!! abstract "Specifikace YAML"
 
-	
-	
 	Viz kapitola [10.2. Styly mapování](https://yaml.org/spec/1.1/#id932806).
 	
 	
 
-### Sekvenční výraz
+### Sekvenční výrazy
 
 Příklad:
 ```yaml
@@ -142,7 +138,7 @@ Příklad:
 - 3 
 ```
 
-Příklad formuláře _flow_:
+Příklad použití ve formě _flow_ :
 ```yaml
 
 !ADD [1, 2, 3]  
@@ -151,8 +147,6 @@ Příklad formuláře _flow_:
 
 !!! abstract "Specifikace YAML"
 
-	
-	
 	Viz kapitola [10.1. Styly sekvencí](https://yaml.org/spec/1.1/#id931088).
 	
 	
@@ -165,14 +159,10 @@ with: [1, 2, 3]
 ```
 
 !!! tip
-
-	
-	
 	
 	Jedná se vlastně o mapovací formu sekvenčního výrazu.
 	
-	
-	
+
 
 ### Skalární výrazy
 
@@ -185,7 +175,6 @@ Příklad:
 
 !!! abstract "Specifikace YAML"
 
-
 		Viz kapitola [9. Skalární styly](https://yaml.org/spec/1.1/#id903915)	
 
 ## Kotvy a aliasy
@@ -193,7 +182,7 @@ Příklad:
 SP-Lang využívá YAML [kotvy](https://yaml.org/spec/1.1/#id899912) a [aliasy](https://yaml.org/spec/1.1/#id902561).
 To znamená, že se můžete odkazovat na výsledek jiného výrazu pomocí _kotvy_.
 Kotva je řetězec začínající znakem "`&`".
-Výsledek výrazu anotovaného kotvou lze pak znovu použít pomocí _aliasu_, což je řetězec začínající na "`*`", který sdílí jméno kotvy.
+Výsledek výrazu anotovaného kotvou lze pak znovu použít pomocí _aliasu_, což je řetězec začínající na "`*`" následovaný jménem kotvy.
 Na jednu kotvu se může odkazovat více aliasů.
 
 Příklad:
@@ -208,7 +197,7 @@ Příklad:
 - *subcount
 ```
 
-Rovná se `1+(2*3)+(2*3)+(2*3)` odpovídající `19`.
+Výsledek je roven `1+(2*3)+(2*3)+(2*3)`, tedy `19`.
 
 
 ## Struktura souboru SP-Lang
@@ -232,19 +221,13 @@ Příklad souboru SP-Lang:
 ```
 
 
-!!! note
+!!! note "Poznámka"
 
-	
-	
-	
 	Soubor SP-Lang vždy začíná řádkem `---`.
 	
 	
 
 !!! info
 
-	
-	
-	
 	Jeden soubor může obsahovat více výrazů pomocí oddělovače YAML (`---`).
 

--- a/cs/docs/tutorial.md
+++ b/cs/docs/tutorial.md
@@ -1,14 +1,14 @@
 ---
 git_commit_hash: b55fa3f
-title: Výukový program
+title: Tutoriál
 ---
 
-# Výukový program SP-Lang
+# Tutoriál k SP-Langu
 
 
 ## Úvod
 
-Vítejte ve výukovém programu SP-Lang.
+Vítejte u tutoriálu k SP-Langu.
 SP-Lang, zkratka pro _Stream Processing Language_, je doménově specifický jazyk (DSL).
 Je založen na YAML, člověkem čitelném jazyku pro serializaci dat.
 Cílem tohoto tutoriálu je představit základní prvky jazyka SP-Lang. 
@@ -20,13 +20,13 @@ Začneme jednoduchým příkladem:
 ```yaml
 
 ---
-Ahoj světe!
+Hello world!
 ```
 
 V jazyce SP-Lang signalizují trojité pomlčky (`---`) začátek kódu.
 
 `Hello world!` zde je hodnota, kterou chcete vrátit.
-V tomto případě je to náš přátelský pozdrav "Hello world!".
+V tomto případě je to náš přátelský pozdrav "Hello world!" ("Ahoj světe!").
 
 
 ## SP-Lang je založen na YAMLu
@@ -36,25 +36,21 @@ YAML klade důraz na jednoduchost a čitelnost, což z něj činí skvělý zák
 
 !!! important
 
-	
-	
-	
-	Jazyk YAML se ve velké míře spoléhá na odsazení, které je v jeho syntaxi významné.
+	Jazyk YAML ve velké míře stojí na odsazování, které je významné v jeho syntaxi.
 	Jako osvědčený postup doporučujeme používat pro odsazení dvě mezery.
 	Upozorňujeme, že v jazyce YAML nejsou podporovány znaky TAB.
-	
-	
+
 
 ## Komentáře
 
-Jak postupujete při psaní kódu, je užitečné zanechávat komentáře.
+Při psaní kódu je užitečné zanechávat komentáře.
 Usnadníte tak ostatním (a svému budoucímu já) pochopit, co váš kód dělá.
 
 ```yaml
 
 # Toto je komentář.
 ---
-Ahoj světe!
+Hello world!
 ```
 
 Komentáře v SP-Langu začínají znakem `#`.
@@ -63,7 +59,7 @@ SP-Lang ignoruje vše, co následuje za `#` na stejném řádku, což je užite�
 
 ## Výrazy SP-Lang
 
-Výrazy v jazyce SP-Lang jsou příkazy, které provádějí operace. Podívejme se na aritmetický příklad:
+Výrazy (Expressions) v jazyce SP-Lang jsou příkazy, které provádějí operace. Podívejme se na příklad s aritmetickými výrazy:
 
 Tento kód sečte dvě čísla, konkrétně vypočítá `5+8`.
 
@@ -82,12 +78,8 @@ Výrazy v jazyce SP-Lang začínají vykřičníkem (`!`).
 
 !!! tip
 
-	
-	
-	
 	Výraz "Expression" je alternativní výraz pro funkci.
-	
-	
+
 
 V tomto příkladu je `!ADD` výraz pro aritmetické sčítání, které sečte zadaná čísla.
 
@@ -106,7 +98,7 @@ To znamená, že může sčítat více vstupních hodnot:
 Tento seznam vstupních hodnot je vytvořen pomocí pomlčky `-` na začátku řádku obsahujícího hodnotu.
 Každý řádek představuje jednotlivou položku seznamu.
 
-Výrazy můžete psát také stručněji pomocí formuláře flow, který lze libovolně kombinovat s výchozím stylem kódu SP-Lang:
+Výrazy můžete psát také stručněji pomocí "flow formy", kterou lze libovolně kombinovat s výchozím stylem kódu SP-Lang:
 ```yaml
 
 ---
@@ -114,9 +106,9 @@ Výrazy můžete psát také stručněji pomocí formuláře flow, který lze li
 ```
 
 
-## Mapování výrazů
+## Mapovací výrazy
 
-Dalším typem výrazu je _mapovací výraz_.
+Dalším typem výrazu je _mapovací výraz_ (_mapping expression_).
 Namísto seznamu vstupů používají mapovací výrazy jména vstupů, která lze nalézt v dokumentaci výrazu.
 ```yaml
 
@@ -126,19 +118,19 @@ what: "FooBar"
 postfix: "Bar"
 ```
 
-Výraz `!ENDSWITH` kontroluje, zda hodnota vstupu `what` končí hodnotou vstupu `postfix`. Pokud ano, vrátí `pravdu`, pokud ne, vrátí `nepravdu`.
+Výraz `!ENDSWITH` kontroluje, zda hodnota zadaná na vstupu `what` končí hodnotou zadanou na vstupu `postfix`. Pokud ano, vrátí `true`, pokud ne, vrátí `false`.
 
-Formulář flow lze použít také s mapovacími výrazy:
+I na mapovací výrazy lze použít flow formu:
 ```yaml
 
 ---
 !ENDSWITH {what: "FooBar", postfix: "Bar"}
 ```
 
-## Kompozice výrazů
+## Skládání výrazů
 
 SP-Lang umožňuje kombinovat výrazy a vytvářet tak složitější a výkonnější řešení.
-Výstup jednoho výrazu můžete "zapojit" do vstupu jiného výrazu.
+Výstup jednoho výrazu můžete vzít za základ pro vstup do jiného výrazu.
 ```yaml
 
 ---
@@ -154,26 +146,27 @@ Tento příklad je ekvivalentní aritmetické operaci `5 * (6 + 2 + 3) * 9 * (10
 
 ## Argumenty
 
-Argumenty jsou způsob, jakým jsou data předávána do jazyka SP-Lang.
-V závislosti na kontextu volání může mít výraz nula, jeden nebo více argumentů.
+Argumenty jsou způsob, jakým do jazyka SP-Lang předáváme data.
+V závislosti na kontextu volání může mít výraz žádný, jeden nebo více argumentů.
 Každý argument má jedinečné jméno.
 
 K hodnotě argumentu můžete přistupovat pomocí výrazu `!ARG`.
 
-V následujícím příkladu je předepsaným argumentem výrazu `jméno`:
+V následujícím příkladu je argumentem výraz `name`:
+
 ```yaml
 
 ---
 !ADD ["Hi ", !ARG name, "!"]
 ```
 
-To by vzalo hodnotu jména a vložilo ji do řetězce, čímž by se vytvořil osobní pozdrav.
+Tento výraz bere hodnotu `name` a vloží ji do řetězce, čímž se vytvoří pozdrav.
 
 
 ## Závěr
 
-V tomto tutoriálu jsme se seznámili se základy jazyka SP-Lang, včetně toho, jak psát jednoduché výrazy, skládat výrazy a používat argumenty.
-S těmito základy jste připraveni začít zkoumat složitější definice zásad v jazyce SP-Lang.
+V tomto tutoriálu jsme se seznámili se základy jazyka SP-Lang, včetně toho, jak psát jednoduché výrazy, složené výrazy a jak používat argumenty.
+S těmito základy jste připraveni začít prozkoumávat složitější definice v jazyce SP-Lang.
 Při dalším pokračování nezapomeňte hojně využívat dokumentaci, abyste porozuměli různým výrazům a jejich požadovaným vstupům.
 
-Šťastné kódování!
+Mnoho zdaru při programování!

--- a/cs/mkdocs.yml
+++ b/cs/mkdocs.yml
@@ -45,6 +45,8 @@ markdown_extensions:
   - pymdownx.emoji:
       emoji_index: !!python/name:materialx.emoji.twemoji
       emoji_generator: !!python/name:materialx.emoji.to_svg
+  - toc:
+      permalink: True
 
 extra:
   social:

--- a/cs/mkdocs.yml
+++ b/cs/mkdocs.yml
@@ -46,7 +46,7 @@ markdown_extensions:
       emoji_index: !!python/name:materialx.emoji.twemoji
       emoji_generator: !!python/name:materialx.emoji.to_svg
   - toc:
-      permalink: True
+      permalink: "¤"
 
 extra:
   social:

--- a/cs/mkdocs.yml
+++ b/cs/mkdocs.yml
@@ -45,6 +45,7 @@ markdown_extensions:
   - pymdownx.emoji:
       emoji_index: !!python/name:materialx.emoji.twemoji
       emoji_generator: !!python/name:materialx.emoji.to_svg
+  - pymdownx.highlight: {}
   - toc:
       permalink: "¤"
 

--- a/docs/expressions/aggregate.md
+++ b/docs/expressions/aggregate.md
@@ -28,7 +28,7 @@ Type: _Sequence_
 	- 4
 	```
 
-	Calculation of the average `(6+2+4)/3`,  the result is `3`.
+	Calculation of the average `(6+2+4)/3`,  the result is `4`.
 
 ---
 
@@ -55,7 +55,7 @@ Type: _Sequence_
 
 ## `!MIN`: Minimum 
 
-Returns a minimum value from the seqence.
+Returns a minimum value from the sequence.
 
 Type: _Sequence_
 
@@ -76,7 +76,7 @@ Type: _Sequence_
 
 ## `!COUNT`: Count number of items 
 
-Counts the number of items in a container.
+Counts the number of items in a list.
 
 Type: _Sequence_
 
@@ -123,6 +123,8 @@ Type: _Sequence_
 	- 101
 	```
 
+	Returns `4`.
+
 ---
 
 ## `!MODE`: Value that appears most often 
@@ -141,16 +143,15 @@ Type: _Sequence_
 
 	```yaml
 	!MODE
-	- -10
-	- -10
+	- 10
+	- 10
 	- -20
 	- -20
-	- 1
-	- 2
-	- 3
-	- 4
-	- 5
+	- 6
+	- 10
 	```
+
+	Returns `10`.
 
 ---
 

--- a/docs/expressions/arithmetics.md
+++ b/docs/expressions/arithmetics.md
@@ -11,7 +11,6 @@ title: Arithmetics
 
 Type: _Sequence_
 
-
 You can add following types:
 
  * Numbers (Integers and floats)
@@ -30,7 +29,7 @@ You can add following types:
     - 6
     ```
 
-  Calculates `4+(-5)+6`, the result is `5`.
+    Calculates `4+(-5)+6`, the result is `5`.
 
 ---
 
@@ -47,6 +46,8 @@ Type: _Sequence_
     - -5
     ```
 
+    Calculates `3-1-(-5)`, the result is `7`.
+
 ---
 
 
@@ -58,10 +59,12 @@ Type: _Sequence_
 
     ```yaml
     !MUL
-    - 1.5
-    - 5.5
-    - 3.2
+    - 7
+    - 11
+    - 13
     ```
+
+    Calculates `7*11*13`, the result is `1001` (which happens to be the [Scheherazade constant](https://en.wikipedia.org/wiki/Scheherazade)).
 
 ---
 
@@ -76,6 +79,8 @@ Type: _Sequence_
     - 21
     - 1.5
     ```
+
+    Calculates `21/5`, the result is `14.0`.
 
 
 ### Division by zero
@@ -94,23 +99,37 @@ The second item is a value that will be returned when such an error occurs.
 - 5.0
 ```
 
-
 ---
 
-## `!MOD`: Reminder 
+## `!MOD`: Remainder 
 
 Type: _Sequence_
 
-
 Calculate the signed remainder of a division (aka modulo operation).
+
+!!! info
+
+	Read more about [modulo](https://en.wikipedia.org/wiki/Remainder) on Wikipedia.
 
 !!! example
 
     ```yaml
     !MOD
     - 21
-    - 1.5
+    - 4
     ```
+
+    Calculates `21 mod 4`, the result is `1`.
+
+!!! example
+
+	```yaml
+	!MOD
+	- -10
+	- 3
+	```
+
+	Calculates `-10 mod 3`, the result is `2`.
 
 ---
 
@@ -128,6 +147,8 @@ Calculate the exponent.
     - 2
     - 8
     ```
+
+    Calculates `2^8`, the result is `16`.
 
 ---
 

--- a/docs/expressions/bitwise.md
+++ b/docs/expressions/bitwise.md
@@ -31,11 +31,11 @@ by: <...>
 
 	```yaml
 	!SHL
-	what: 60
+	what: 9
 	by: 2
 	```
 
-	The result is: `240 = (60*2^2)`, `2^2 = 4`.
+	`9` is represented by the binary value `1001`. The left logical shift moves the bits to the left by 2. The result is `100100`, which is `36` in the base-ten system. This is the same result as `9 * (2^2)`.
 
 ---
 
@@ -58,11 +58,11 @@ by: <...>
 
 	```yaml
 	!SHR
-	what: 2048
-	by: 4
+	what: 16
+	by: 3
 	```
 
-	The result is: `128 = (2048/2^4)`, `2^4 = 16`.
+	`16` is represented by `10000`. The logical shift moves the bits to the right by `3`. The result is `10`, which is `2` in base-ten system. This is the same result as `16 / (2^3)`.
 
 
 --- 

--- a/docs/expressions/comparisons.md
+++ b/docs/expressions/comparisons.md
@@ -150,4 +150,4 @@ Evaluate to `true` if it finds a value `what` in the specified value `where` and
     where: "John Willy Boo"
     ```
 
-    Check for a presence of the substring "Willy" in the `John Willy Boo` value. Returns "true".
+    Check for a presence of the substring "Willy" in the `John Willy Boo` value. Returns `true`.

--- a/docs/expressions/comparisons.md
+++ b/docs/expressions/comparisons.md
@@ -150,4 +150,4 @@ Evaluate to `true` if it finds a value `what` in the specified value `where` and
     where: "John Willy Boo"
     ```
 
-    Check for a presence of the substring "Willy" in the `where` value. Returns "true".
+    Check for a presence of the substring "Willy" in the `John Willy Boo` value. Returns "true".

--- a/docs/expressions/comparisons.md
+++ b/docs/expressions/comparisons.md
@@ -20,7 +20,7 @@ Test expression evaluates inputs and returns boolean value `true` or `false` bas
     - 3
     ```
 
-    This compares `count` argument with `3`.
+    This compares `count` argument with `3`, returns `count == 3`
 
 
 ---
@@ -40,6 +40,7 @@ This is negative counterpart to `!EQ`.
     - Frodo
     ```
 
+    This compares `name` argument with `Frodo`, returns `name != Frodo`.
 
 ---
 
@@ -123,7 +124,7 @@ where: <...>
 
 The `!IN` expression is used to check if a value `what` exists in a value `where` or not.
 Value `where` is a string, container (list, set, dictionary), structural type etc.
-Evaluate to "true" if it finds a value `what` in the specified value `where` and false otherwise.
+Evaluate to `true` if it finds a value `what` in the specified value `where` and `false` otherwise.
 
 !!! example
 

--- a/docs/expressions/control.md
+++ b/docs/expressions/control.md
@@ -13,7 +13,6 @@ SP-Lang provides a variety of control flow statements.
 
 Type: _Mapping_.
 
-
 The `!IF` expression is a decision-making expression that guides the evaluation to make decisions based on specified test.
 
 ```yaml
@@ -23,10 +22,12 @@ then: <expression>
 else: <expression>
 ```
 
+Based on the value of `test`, the branch is evaluated:
 
-`test` should provide boolean value, based on this value `then` (for `true`) or `else` (for `false`) branch is evaluated.
+- `then` in case of `test !EQ true`
+- `else` in case of `test !EQ false`
 
-`then` and `else` have to return the same type, which will be also the type of the `!IF` return value.
+Both `then` and `else` have to return the same type, which will be also the type of the `!IF` return value.
 
 
 !!! example
@@ -86,7 +87,7 @@ If `else` is not provided, then `WHEN` returns `False`.
         - !ARG key
         - 34
       then:
-        "Thirty four"
+        "thirty four"
 
     # Range match
     - test:
@@ -108,9 +109,8 @@ If `else` is not provided, then `WHEN` returns `False`.
       then:
         "seventy five, seven, nine"
 
-
     - else:
-        "Unknown"
+        "unknown"
     ```
 
 --- 
@@ -141,13 +141,13 @@ The expression fails with error when no matching `<value>` is found and `else` b
 
     ```yaml
     !MATCH
-    what: 1
+    what: !ARG value
     with:
-      1: "One"
-      2: "Two"
-      3: "Three"
+      1: "one"
+      2: "two"
+      3: "three"
     else:
-      "Other number"
+      "other number"
     ```
 
 
@@ -165,13 +165,11 @@ The expression fails with error when no matching `<value>` is found and `else` b
   
 ---
 
-## `!TRY`: Execute till first non-error expression  
-
+## `!TRY`: Execute till first error expression  
 
 Type: _Sequence_
 
 ```yaml
-
 !TRY
 - <expression>
 - <expression>

--- a/docs/expressions/control.md
+++ b/docs/expressions/control.md
@@ -165,7 +165,7 @@ The expression fails with error when no matching `<value>` is found and `else` b
   
 ---
 
-## `!TRY`: Execute till first error expression  
+## `!TRY`: Execute till first non-error expression  
 
 Type: _Sequence_
 
@@ -210,7 +210,7 @@ The result is a new list with transformed elements.
       !ADD [!ARG x, 10]
     ```
 
-    Result is `[11, 12, 13, 14, 15, 16, 17]`.
+    The result is `[11, 12, 13, 14, 15, 16, 17]`.
 
 ---
 
@@ -227,7 +227,7 @@ initval: <expression>
 fold: <left|right>
 ```
 
-The `apply` expression is applied on each element in the `what` sequence with the argument `a` containing an aggregation of the reduce operation and argument 'b' containing the respective item value.
+The `apply` expression is applied on each element in the `what` sequence with the argument `a` containing an aggregation of the reduce operation and argument `b` containing the respective item value.
 
 The `initval` expression provides the initial value for the `a` argument.
 
@@ -244,5 +244,5 @@ An optional `fold` value specified a "left folding" (`left`, default) or a "righ
       !ADD [!ARG a, !ARG b]
     ```
 
-    Calculates a sum of the sequence with an initial value -1.  
-    Result is `18` = `-10 + 1 + 2 + 3 + 4 + 5 + 6 + 7`.
+    Calculates a sum of the sequence with an initial value `-10`.  
+    Result is `18 = -10 + 1 + 2 + 3 + 4 + 5 + 6 + 7`.

--- a/docs/expressions/datetime.md
+++ b/docs/expressions/datetime.md
@@ -119,35 +119,31 @@ The `timezone` is optional information, if provided, the time will be printed in
 
 ### Format
 
-* `%H`: Hour (24-hour clock) as a zero-padded decimal number.
-* `%M`: Minute as a zero-padded decimal number.
-* `%S`: Second as a zero-padded decimal number.
-* `%f`: Microsecond as a decimal number, zero-padded to 6 digits.
-* `%I`: Hour (12-hour clock) as a zero-padded decimal number.
-* `%p`: Locale’s equivalent of either AM or PM.
-
-* `%d`: Day of the month as a zero-padded decimal number.
-* `%m`: Month as a zero-padded decimal number.
-* `%y`: Year without century as a zero-padded decimal number.
-* `%Y`: Year with century as a decimal number.
-
-* `%z`: UTC offset.
-
-* `%a`: Weekday as abbreviated name.
-* `%A`: Weekday as full name.
-* `%w`: Weekday as a decimal number, where 0 is Sunday and 6 is Saturday.
-* `%b`: Month as abbreviated name.
-* `%B`: Month as full name.
-* `%j`: Day of the year as a zero-padded decimal number.
-* `%U`: Week number of the year (Sunday as the first day of the week) as a zero-padded decimal number. All days in a new year preceding the first Sunday are considered to be in week 0.
-* `%W`: Week number of the year (Monday as the first day of the week) as a zero-padded decimal number. All days in a new year preceding the first Monday are considered to be in week 0.
-
-* `%c`: Date and time representation.
-* `%x`: Date representation.
-* `%X`: Time representation.
-
-* `%%`: A literal '%' character.
-
+| Directive | Component |
+| --- | --- |
+|`%H`| Hour (2-hour clock) as a zero-padded decimal number.|
+|`%M`| Minute as a zero-padded decimal number.|
+|`%S`| Second as a zero-padded decimal number.|
+|`%f`| Microsecond as a decimal number, zero-padded to 6 digits.|
+|`%I`| Hour (12-hour clock) as a zero-padded decimal number.|
+|`%p`| Locale’s equivalent of either AM or PM. |
+|`%d`| Day of the month as a zero-padded decimal number.|
+|`%m`| Month as a zero-padded decimal number.|
+|`%y`| Year without century as a zero-padded decimal number.|
+|`%Y`| Year with century as a decimal number|
+|`%z`| UTC offset|
+|`%a`| Weekday as abbreviated name.
+|`%A`| Weekday as full name.
+|`%w`| Weekday as a decimal number, where 0 is Sunday and 6 is Saturday.|
+|`%b`| Month as abbreviated name.|
+|`%B`| Month as full name.|
+|`%j`| Day of the year as a zero-padded decimal number.|
+|`%U`| Week number of the year (Sunday as the first day of the week) as a zero-padded decimal number. All days in a new year preceding the first Sunday are considered to be in week 0.|
+|`%W`| Week number of the year (Monday as the first day of the week) as a zero-padded decimal number. All days in a new year preceding the first Monday are considered to be in week 0. |
+|`%c`| Date and time representation.|
+|`%x`| Date representation.|
+|`%X`| Time representation.|
+|`%%`| A literal '%' character.|
 
 !!! example
 
@@ -158,7 +154,7 @@ The `timezone` is optional information, if provided, the time will be printed in
 	timezone: "Europe/Prague"
 	```
 
-	Prints the current local time as eg. `2022-12-31 12:34:56` using the timezone "Europe/Prague".
+	Prints the current local time as e.g. `2022-12-31 12:34:56` using the timezone "Europe/Prague".
 
 
 ---
@@ -180,7 +176,7 @@ timezone: <timezone>
 Parse `what` string input using `format` string.
 The `timezone` information is optional, if provided, then it specifies local timezone of the `what` string.
 
-See "Format" chapter above for more information about `format`.
+See [Format](#format) chapter above for more information about `format`.
 
 
 !!! example
@@ -212,16 +208,16 @@ The `timezone` if optional, if not provided UTC timezone is used.
 
 ### Components
 
-* `year`, `y`: Year
-* `month`, `m`: Month
-* `day`, `d`: Day
-
-* `hour`, `H`: Hour
-* `minute`, `M`: Minute
-* `second`, `S`: Second
-* `microsecond`, `f`: Microsecond
-
-* `weekday`, `w`: Day of the week
+| Directive | Component |
+| --- | --- |
+|`year`, `y`| Year |
+| `month`, `m`| Month |
+| `day`, `d`| Day |
+| `hour`, `H`| Hour |
+| `minute`, `M`| Minute |
+| `second`, `S`| Second |
+| `microsecond`, `f`| Microsecond |
+| `weekday`, `w`| Day of the week |
 
 !!! example
 
@@ -232,7 +228,7 @@ The `timezone` if optional, if not provided UTC timezone is used.
 	timezone: "Europe/Prague"
 	```
 
-	Get "hours" component of the current timestamp, using the "Europe/Prague" timezone.
+	Get `hours` component of the current timestamp, using the "Europe/Prague" timezone.
 
 
 !!! example "Example: Get a current year"

--- a/docs/expressions/dict.md
+++ b/docs/expressions/dict.md
@@ -5,13 +5,14 @@ title: Dictionary
 # Dictionary expression
 
 
-The dict (aka dictionary) store a collection of (key, value) pairs, such that each possible key appears at most once in the collection.
+The **dict** (aka dictionary) store a collection of (key, value) pairs, such that each possible key appears at most once in the collection.
 Keys in the dictionary must be of the same type as well as values.
-The set is one of basic data structures provided by SP-Lang.
 
 An item is a (key, value) pair, represented as a tuple.
 
-Hint: You may know this structure under alernative names "associative array" or "map".
+!!! Hint
+
+	You may know this structure under alternative names "associative array" or "map".
 
 --- 
 
@@ -30,42 +31,42 @@ with:
 
 !!! hint
 
-    Use `!COUNT` to determine number of items in the dictionary.
+	Use [`!COUNT`](../aggregate/#count-count-number-of-items) to determine number of items in the dictionary.
 
 
 !!! example
 
-    There are several ways, how a dictionary can be specified in SP-Lang:
+	There are several ways, how a dictionary can be specified in SP-Lang:
 
-    ```yaml
-    !DICT
-    with:
-      key1: "One"
-      key2: "Two"
-      key3: "Three"
-    ```
+	```yaml
+	!DICT
+	with:
+	  key1: "One"
+	  key2: "Two"
+	  key3: "Three"
+	```
 
-    Implicit dictionary:
+	Implicit dictionary:
 
-    ```yaml
-    ---
-    key1: "One"
-    key2: "Two"
-    key3: "Three"
-    ```
+	```yaml
+	---
+	key1: "One"
+	key2: "Two"
+	key3: "Three"
+	```
 
-    Consise dictionary using `!!dict` and YAML flow style:
+	Concise dictionary using `!!dict` and YAML flow style:
 
-    ```yaml
-    !!dict {key1: "One", key2: "Two", key3: "Three"}
-    ```
+	```yaml
+	!!dict {key1: "One", key2: "Two", key3: "Three"}
+	```
 
 ### Type specification
 
 The type of dictionary is denoted as `{Tk:Tv}`, where `Tk` is a type of the key and `Tv` is a type of value.
-For more info about the dictionary type, continue to the relevant chapter in a [type system](../language/types#dictionary).
+For more info about the dictionary type, continue to the relevant chapter in a [type system](../../language/types#dictionary).
 
-The dictionaty will try to infere its type based on the items added.
+The dictionary will try to infer its type based on the items added.
 The type of the first item will likely provide the key type `Tk` and the value type `Tv`.
 If the dictionary is empty, its infered type is `{str:si64}`.
 
@@ -81,8 +82,7 @@ with:
   ...
 ```
 
-`type` is an optional argument containing a string with the dictionary signature.
-This signature will be used for this signature instead of type inference from childs.
+`type` is an optional argument containing a string with the dictionary signature that will be used instead of type inference from children.
 
 In the above example, the type of the dictionary is `{str:any}`, the type of key is `str` and the type of values is `any`.
 
@@ -109,18 +109,18 @@ If the `key` is not found, return `default` or error if `default` is not provide
 
 !!! example
 
-    ```yaml
-    !GET
-    what: 3
-    from:
-      !DICT
-      with:
-        1: "One"
-        2: "Two"
-        3: "Three"
-    ```
+	```yaml
+	!GET
+	what: 3
+	from:
+	  !DICT
+	  with:
+		1: "One"
+		2: "Two"
+		3: "Three"
+	```
 
-    Returns `Three`.
+	Returns `Three`.
 
 --- 
 
@@ -136,17 +136,19 @@ where: <dict>
 
 Check if `key` is present in the `dict`.
 
-Note: The expression `!IN` is described in the "Tests" chapter.
+!!! note
+
+	The expression `!IN` is described in the [Comparisons](../comparisons/#in-membership-test) chapter.
 
 !!! example
 
-    ```yaml
-    !IN
-    what: 3
-    where:
-      !DICT
-      with:
-        1: "One"
-        2: "Two"
-        3: "Three"
-    ```
+	```yaml
+	!IN
+	what: 3
+	where:
+	  !DICT
+	  with:
+		1: "One"
+		2: "Two"
+		3: "Three"
+	```

--- a/docs/expressions/directives.md
+++ b/docs/expressions/directives.md
@@ -19,7 +19,7 @@ The `!INCLUDE` directive is used to paste a content of given file into current f
 If included file is not found, SP-Lang renders error.
 
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !INCLUDE <filename>

--- a/docs/expressions/directives.md
+++ b/docs/expressions/directives.md
@@ -34,21 +34,20 @@ It could be:
   
 `.yaml` extension is optional and will be added to the `filename` if missing.
 
-### Example
+!!! example
 
-```yaml
-!INCLUDE other_file.yaml
-```
+  ```yaml
+  !INCLUDE other_file.yaml
+  ```
 
-This is a simple inclusion of the `other_file.yaml`.
-  
+  This is a simple inclusion of the `other_file.yaml`.
 
-```yaml
-!MATCH
-what: !GET {...}
-with:
-  'group1': !INCLUDE inc_group1
-  'group2': !INCLUDE inc_group2
-```
+  ```yaml
+  !MATCH
+  what: !GET {...}
+  with:
+    'group1': !INCLUDE inc_group1
+    'group2': !INCLUDE inc_group2
+  ```
 
-In this example, `!INCLUDE` is used to decompose a larger expression into a logically separated files.
+  In this example, `!INCLUDE` is used to decompose a larger expression into a logically separated files.

--- a/docs/expressions/function.md
+++ b/docs/expressions/function.md
@@ -12,7 +12,7 @@ title: Functions
 
 Type: _Scalar_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !ARGUMENT name
@@ -46,7 +46,7 @@ Type: _Mapping_.
     It means that in a majority of cases, `!FUNCTION` can be skipped, and only `do` section is provided
 
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !FUNCTION
@@ -95,7 +95,7 @@ The `!SELF` provides an ability to recursively apply "self" aka a current functi
 
 Type: _Mapping_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !SELF

--- a/docs/expressions/function.md
+++ b/docs/expressions/function.md
@@ -66,32 +66,32 @@ do:
     `!FN` is an concise version of `!FUNCTION`.
 
 
-### Example
+!!! example
 
-```yaml
-!FUNCTION
-arguments:
-  a: si64
-  b: si32
-  c: si32
-  d: si32
-returns: fp64
-do:
-  !MUL
-  - !ARGUMENT a
-  - !ARGUMENT b
-  - !ARGUMENT c
-  - !ARGUMENT d
-```
+    ```yaml
+    !FUNCTION
+    arguments:
+      a: si64
+      b: si32
+      c: si32
+      d: si32
+    returns: fp64
+    do:
+      !MUL
+      - !ARGUMENT a
+      - !ARGUMENT b
+      - !ARGUMENT c
+      - !ARGUMENT d
+    ```
 
-This expression defines a function that takes four arguments (`a`, `b`, `c`, and `d`) with respective data types (`si64`, `si32`, `si32`, and `si32`) and returns a result of type `fp64`.
-The function multiplies the four input arguments (`a`, `b`, `c`, and `d`) and returns the product as a floating-point number (`fp64`).
+    This expression defines a function that takes four arguments (`a`, `b`, `c`, and `d`) with respective data types (`si64`, `si32`, `si32`, and `si32`) and returns a result of type `fp64`.
+    The function multiplies the four input arguments (`a`, `b`, `c`, and `d`) and returns the product as a floating-point number (`fp64`).
 
 --- 
 
 ## `!SELF`: Apply a current function  
 
-The `!SELF` provides an ability to recursivelly apply "self" aka a current function.
+The `!SELF` provides an ability to recursively apply "self" aka a current function.
 
 Type: _Mapping_.
 
@@ -106,24 +106,24 @@ arg2: <value>
 
 !!! note
 
-    `!SELF` expression is the [Y combinator](https://en.wikipedia.org/wiki/Fixed-point_combinator#Y_combinator).
+    `!SELF` expression is the so called [Y combinator](https://en.wikipedia.org/wiki/Fixed-point_combinator#Y_combinator).
 
 
-### Example
+!!! example
 
 
-```yaml
-!FUNCTION
-arguments: {x: int}
-returns: int
-do:
-  !IF # value <= 1
-  test: !GT [!ARG x, 1]
-  then: !MUL [!SELF {x: !SUB [!ARG x, 1]}, !ARG x]
-  else: 1
-```
+	```yaml
+	!FUNCTION
+	arguments: {x: int}
+	returns: int
+	do:
+	!IF # value <= 1
+	test: !GT [!ARG x, 1]
+	then: !MUL [!SELF {x: !SUB [!ARG x, 1]}, !ARG x]
+	else: 1
+	```
 
-This expression defines a recursive function that takes a single integer argument `x` and returns an integer result.
-The function calculates the factorial of the input argument `x` using an if-else statement.
-If the input value `x` is greater than 1, the function multiplies `x` by the factorial of (`x` - 1), computed by calling itself recursively.
-If the input value `x` is 1 or less, the function returns 1.
+	This expression defines a recursive function that takes a single integer argument `x` and returns an integer result.
+	The function calculates the factorial of the input argument `x` using an if-else statement.
+	If the input value `x` is greater than 1, the function multiplies `x` by the factorial of (`x` - 1), computed by calling itself recursively.
+	If the input value `x` is 1 or less, the function returns 1.

--- a/docs/expressions/ip.md
+++ b/docs/expressions/ip.md
@@ -50,36 +50,36 @@ subnet:
 
 Test if `what` IP address belongs to a `subnet` or subnets , returns `true` if yes otherwise `false`.
 
-### Example with a single subnet
+!!! example "Example with a single subnet"
 
-```yaml
-!IP.INSUBNET
-what: 192.168.1.1
-subnet: 192.168.0.0/16
-```
-
-
-### Example with multiple subnets
-
-```yaml
-!IP.INSUBNET
-what: 1.2.3.4
-subnet:
-  - 10.0.0.0/8
-  - 172.16.0.0/12
-  - 192.168.0.0/16
-```
-
-The test that check if IP address is from IPv4 private address space as defined in [RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918).
+	```yaml
+	!IP.INSUBNET
+	what: 192.168.1.1
+	subnet: 192.168.0.0/16
+	```
 
 
-More compact form:
+!!! example "Example with multiple subnets"
 
-```yaml
-!IP.INSUBNET
-what: 1.2.3.4
-subnet: [10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16]
-```
+	```yaml
+	!IP.INSUBNET
+	what: 1.2.3.4
+	subnet:
+		- 10.0.0.0/8
+		- 172.16.0.0/12
+		- 192.168.0.0/16
+	```
+
+	The test that check if IP address is from IPv4 private address space as defined in [RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918).
+
+
+	More compact form:
+
+	```yaml
+	!IP.INSUBNET
+	what: 1.2.3.4
+	subnet: [10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16]
+	```
 
 
 ---

--- a/docs/expressions/ip.md
+++ b/docs/expressions/ip.md
@@ -15,7 +15,7 @@ IPv4 are mapped into IPv6 space, using [RFC 4291 "IPv4-Mapped IPv6 Address"](htt
 
 Type: _Mapping_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !IP.FORMAT
@@ -31,7 +31,7 @@ Convert the internal representation of the IP address into a string.
 
 Type: _Mapping_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !IP.INSUBNET

--- a/docs/expressions/json.md
+++ b/docs/expressions/json.md
@@ -14,7 +14,7 @@ SP-Lang offers a [high-speed access](https://simdjson.org) to JSON data objects.
 Type: _Mapping_.
 
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !GET
@@ -82,7 +82,7 @@ The schema will be applied to infer the type of the item but for more complex ac
 
 Type: _Mapping_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !JSON.PARSE

--- a/docs/expressions/json.md
+++ b/docs/expressions/json.md
@@ -30,23 +30,23 @@ If the item is not found, return `default` or error if `default` is not provided
 
 You may optionally specify the item type by `type`.
 
-### Example
+!!! example
 
-JSON (aka `!ARG jsonmessage`):
+	JSON (aka `!ARG jsonmessage`):
 
-```json
-{
-  "foo.bar": "Example"
-}
-```
+	```json
+	{
+	"foo.bar": "Example"
+	}
+	```
 
-Get the field `foo.bar` from a JSON above:
+	Get the field `foo.bar` from a JSON above:
 
-```yaml
-!GET
-what: foo.bar
-from: !ARG jsonmessage
-```
+	```yaml
+	!GET
+	what: foo.bar
+	from: !ARG jsonmessage
+	```
 
 
 ### JSON Pointer
@@ -55,24 +55,26 @@ If you want to access the item in the nested JSON, you need to use a [JSON Point
 
 The schema will be applied to infer the type of the item but for more complex access, the `type` argument is recommended.
 
-Nested JSON (aka `!ARG jsonmessage`):
+!!! example
 
-```json
-{
-  "foo": {
-    "bar": "Example"
-  }
-}
-```
+	Nested JSON (aka `!ARG jsonmessage`):
 
-Example of extraction of the string from the nested JSON:
+	```json
+	{
+	"foo": {
+		"bar": "Example"
+	}
+	}
+	```
 
-```yaml
-!GET
-what: /foo/bar
-type: str
-from: !ARG jsonmessage
-```
+	Example of extraction of the string from the nested JSON:
+
+	```yaml
+	!GET
+	what: /foo/bar
+	type: str
+	from: !ARG jsonmessage
+	```
 
 --- 
 
@@ -95,13 +97,13 @@ Optional argument `schema` specifies the schema to be applied.
 The default schema is build-in `ANY`.
 
 
-### Example
+!!! example
 
-```yaml
-!JSON.PARSE
-what: |
-  {
-    "string1": "Hello World!",
-    "string2": "Goodbay ..."
-  }
-```
+	```yaml
+	!JSON.PARSE
+	what: |
+	{
+		"string1": "Hello World!",
+		"string2": "Goodby ..."
+	}
+	```

--- a/docs/expressions/list.md
+++ b/docs/expressions/list.md
@@ -20,7 +20,7 @@ Items in the list must be of the same type.
 
 Type:  _Implicit sequence_, _Mapping_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !LIST
@@ -88,7 +88,7 @@ There are several ways, how a list can be specified in SP-Lang:
 Type: _Mapping_.
 
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !GET

--- a/docs/expressions/list.md
+++ b/docs/expressions/list.md
@@ -28,52 +28,58 @@ Type:  _Implicit sequence_, _Mapping_.
 - ...
 ```
 
-_Hint: Use `!COUNT` to determine number of items in the list._
+!!! hint
+
+	Use `!COUNT` to determine number of items in the list.
 
 
-### Examples
 
 There are several ways, how a list can be specified in SP-Lang:
 
-```yaml
-!LIST
-- "One"
-- "Two"
-- "Three"
-- "Four"
-- "Five"
-```
+!!! example
 
+	```yaml
+	!LIST
+	- "One"
+	- "Two"
+	- "Three"
+	- "Four"
+	- "Five"
+	```
 
-Implicit list using [YAML block sequences](https://yaml.org/spec/1.2.2/#821-block-sequences):
+!!! example
 
-```yaml
-- "One"
-- "Two"
-- "Three"
-- "Four"
-- "Five"
-```
+	Implicit list using [YAML block sequences](https://yaml.org/spec/1.2.2/#821-block-sequences):
 
+	```yaml
+	- "One"
+	- "Two"
+	- "Three"
+	- "Four"
+	- "Five"
+	```
 
-Implicit list using [YAML flow sequences](https://yaml.org/spec/1.2.2/#741-flow-sequences):
+!!! example
 
-```yaml
-["One", "Two", "Three", "Four", "Five"]
-```
+	Implicit list using [YAML flow sequences](https://yaml.org/spec/1.2.2/#741-flow-sequences):
 
+	```yaml
+	["One", "Two", "Three", "Four", "Five"]
+	```
 
-The mapping form:
+!!! example
 
-```yaml
-!LIST
-with:
-  - "One"
-  - "Two"
-  - "Three"
-  - "Four"
-  - "Five"
-```
+	The mapping form:
+
+	```yaml
+	!LIST
+	with:
+	- "One"
+	- "Two"
+	- "Three"
+	- "Four"
+	- "Five"
+	```
 
 --- 
 
@@ -98,36 +104,38 @@ Items are indexed from the 0, it means that the first item in the list has an in
 If the `index` is out of bound of the list, the statement returns with error.
 
 
-### Examples
+!!! example
 
-```yaml
-!GET
-what: 3
-from:
-  !LIST
-  - 1
-  - 5
-  - 30
-  - 50
-  - 80
-  - 120
-```
+	```yaml
+	!GET
+	what: 3
+	from:
+	!LIST
+	- 1
+	- 5
+	- 30
+	- 50
+	- 80
+	- 120
+	```
 
-Returns `50`.
+	Returns `50`.
 
 
-```yaml
-!GET
-what: -1
-from:
-  !LIST
-  - 1
-  - 5
-  - 30
-  - 50
-  - 80
-  - 120
-```
+!!! example
 
-Returns the last item in the list, which is `120`.
+	```yaml
+	!GET
+	what: -1
+	from:
+	!LIST
+	- 1
+	- 5
+	- 30
+	- 50
+	- 80
+	- 120
+	```
+
+	Returns the last item in the list, which is `120`.
 

--- a/docs/expressions/logic.md
+++ b/docs/expressions/logic.md
@@ -9,7 +9,7 @@ Logic expressions operates with truth values `true` and `false`.
 
 !!! info "Logic expressions are representations of boolean algebra"
 
-    For more informations, continue to [boolean algebra](https://en.wikipedia.org/wiki/Boolean_algebra) page at Wikipedia.
+	For more information, continue to [boolean algebra](https://en.wikipedia.org/wiki/Boolean_algebra) page at Wikipedia.
 
 
 ---
@@ -23,7 +23,7 @@ Type: _Sequence_
 
 ### Synopsis
 
-```
+```yaml
 !AND
 - <condition 1>
 - <condition 2>
@@ -35,41 +35,41 @@ The conditions are evaluated from top to bottom, and the evaluation process stop
 
 !!! info "Logical conjunction"
 
-    For more informations, continue to [Logical conjunction](https://en.wikipedia.org/wiki/Logical_conjunction) page at Wikipedia.
+    For more information, continue to [Logical conjunction](https://en.wikipedia.org/wiki/Logical_conjunction) page at Wikipedia.
 
 
-### Example
+!!! example
 
-```yaml
-!AND
-- !EQ
-  - !ARG vendor
-  - TeskaLabs
-- !EQ
-  - !ARG product
-  - LogMan.io
-- !EQ
-  - !ARG version
-  - v23.10
-```
+	```yaml
+	!AND
+	- !EQ
+	- !ARG vendor
+	- TeskaLabs
+	- !EQ
+	- !ARG product
+	- LogMan.io
+	- !EQ
+	- !ARG version
+	- v23.10
+	```
 
-In this example, if all of the conditions evaluate to true, the entire logical `!AND` expression will be true.
-If any of the conditions are false, the logical `!AND` expression will be false.
+	In this example, if all of the conditions evaluate to true, the entire logical `!AND` expression will be true.
+	If any of the conditions are false, the logical `!AND` expression will be false.
 
 
 ### Bitwise  `!AND`
 
 When `!AND` is applied on integer types, instead on booleans, it provides a bitwise AND.
 
-### Example
+!!! example
 
-```yaml
-!AND
-- !ARG PRI
-- 7
-```
+	```yaml
+	!AND
+	- !ARG PRI
+	- 7
+	```
 
-In this example, the argument `PRI` is masked with 7 (in binary `00000111`).
+	In this example, the argument `PRI` is masked with 7 (in binary `00000111`).
 
 ---
 
@@ -82,7 +82,7 @@ Type: _Sequence_
 
 ### Synopsis
 
-```
+```yaml
 !OR
 - <condition 1>
 - <condition 2>
@@ -96,53 +96,52 @@ The conditions are evaluated from top to bottom, and the evaluation process stop
 
     For more informations, continue to [Logical disjunction](https://en.wikipedia.org/wiki/Logical_disjunction) page at Wikipedia.
 
+!!! example
 
-### Example
+	```yaml
+	!OR
+	- !EQ
+	- !ARG description
+	- unauthorized access
+	- !EQ
+	- !ARG reason
+	- brute force
+	- !EQ
+	- !ARG message
+	- malware detected
+	```
 
-```yaml
-!OR
-- !EQ
-  - !ARG description
-  - unauthorized access
-- !EQ
-  - !ARG reason
-  - brute force
-- !EQ
-  - !ARG message
-  - malware detected
-```
+	In this example, the expression is true when any of the following conditions is met:
 
-In this example, the expression is true when any of the following conditions is met:
-
-1. The `description` field matches the string "unauthorized access"
-2. The `reason` field matches the string "brute force"
-3. The `message` field matches the string "malware detected"
+	1. The `description` field matches the string "unauthorized access"
+	2. The `reason` field matches the string "brute force"
+	3. The `message` field matches the string "malware detected"
 
 
 ### Bitwise `!OR`
 
 When `!OR` is applied on integer types, instead on booleans, it provides a bitwise OR.
 
-### Example
+!!! example
 
-```yaml
-!OR
-- 1  # Read access (binary 001, decimal 1)
-- 4  # Execute access (binary 100, decimal 4)
-```
+	```yaml
+	!OR
+	- 1  # Read access (binary 001, decimal 1)
+	- 4  # Execute access (binary 100, decimal 4)
+	```
 
-In this example, the expression is evaluated to 5.
+	In this example, the expression is evaluated to 5.
 
-This is because, in a bitwise `!OR` operation, each corresponding bit in the binary representation of the two numbers is combined using the `!OR` expression:
+	This is because, in a bitwise `!OR` operation, each corresponding bit in the binary representation of the two numbers is combined using the `!OR` expression:
 
-```
-001 (read access)
-100 (execute access)
----
-101 (combined permissions)
-```
+	```
+	001 (read access)
+	100 (execute access)
+	---
+	101 (combined permissions)
+	```
 
-The expression calculates the permissions with the resulting value (binary 101, decimal 5) from the bitwise OR operation, combining both read and execute access.
+	The expression calculates the permissions with the resulting value (binary 101, decimal 5) from the bitwise OR operation, combining both read and execute access.
 
 ---
 
@@ -156,14 +155,14 @@ Type: _Mapping_.
 
 ### Synopsis
 
-```
+```yaml
 !NOT
 what: <expression>
 ```
 
 !!! info "Negation"
 
-    For more informations, continue to [Negation](https://en.wikipedia.org/wiki/Negation) page at Wikipedia.
+	For more information, continue to [Negation](https://en.wikipedia.org/wiki/Negation) page at Wikipedia.
 
 
 ### Bitwise `!NOT`

--- a/docs/expressions/logic.md
+++ b/docs/expressions/logic.md
@@ -21,7 +21,7 @@ It is used to create more restrictive and precise conditions.
 
 Type: _Sequence_
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !AND
@@ -80,7 +80,7 @@ It is used to create more flexible and inclusive conditions.
 
 Type: _Sequence_
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !OR
@@ -153,7 +153,7 @@ It is used to exclude specific conditions when certain conditions are not met.
 Type: _Mapping_.
 
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !NOT

--- a/docs/expressions/parsec.md
+++ b/docs/expressions/parsec.md
@@ -12,9 +12,9 @@ In this context, a parser is a function that takes string as input and produces 
 
 Parsec expressions are divided into two groups: parsers and combinators.
 
-*Parsers* can be seen as the fundamental units or building blocks. They are responsible for recognizing and processing specific patterns or elements within the input string.
+_Parsers_ can be seen as the fundamental units or building blocks. They are responsible for recognizing and processing specific patterns or elements within the input string.
 
-*Combinators*, on the other hand, are operators or functions that allow the combination and composition of parsers.
+_Combinators_, on the other hand, are operators or functions that allow the combination and composition of parsers.
 
 Every expression starts with `!PARSE.` prefix.
 
@@ -32,12 +32,13 @@ Type: _Parser_.
 ```
 
 
-### Example
-_Input string:_ `2`
+!!! example
 
-```yaml
-!PARSE.DIGIT
-```
+	_Input string:_ `2`
+
+	```yaml
+	!PARSE.DIGIT
+	```
 
 ---
 
@@ -60,15 +61,14 @@ Fields `min`, `max` and `exactly` are optional.
 
 	`Exactly` field can't be used together with `min` or `max` fields. And of course `max` value can't be less than `min` value.
 
+!!! example
 
+	_Input string:_ `123`
 
-### Example
-_Input string:_ `123`
-
-```yaml
-!PARSE.DIGITS
-max: 4
-```
+	```yaml
+	!PARSE.DIGITS
+	max: 4
+	```
 
 <details>
   <summary>More examples</summary>
@@ -107,12 +107,13 @@ Type: _Parser_.
 !PARSE.LETTER
 ```
 
-### Example
-_Input string:_ `A`
+!!! example
 
-```yaml
-!PARSE.LETTER
-```
+	_Input string:_ `A`
+
+	```yaml
+	!PARSE.LETTER
+	```
 
 
 ---
@@ -128,11 +129,13 @@ Type: _Parser_.
 !PARSE.CHAR
 ```
 
-### Example
-_Input string:_ `@`
-```yaml
-!PARSE.CHAR
-```
+!!! example
+
+	_Input string:_ `@`
+
+	```yaml
+	!PARSE.CHAR
+	```
 
 
 ---
@@ -155,16 +158,18 @@ Fields `min`, `max` and `exactly` are optional.
 
 	`Exactly` field can't be used together with `min` or `max` fields. And of course `max` value can't be less than `min` value.
 
-### Example
-_Input string:_ `name@123_`
+!!! example
 
-```yaml
-!PARSE.CHARS
-max: 8
-```
+	_Input string:_ `name@123_`
+
+	```yaml
+	!PARSE.CHARS
+	max: 8
+	```
+
 !!! tip
 
-    Use `!PARSE.CHARS` without fields to parse till the end of the string.
+	Use `!PARSE.CHARS` without fields to parse till the end of the string.
 
 
 <details>
@@ -236,13 +241,14 @@ or shorter version:
 !PARSE.ONEOF <...>
 ```
 
-## Example
-_Input string:_ `Wow`==!==
+!!! example
 
-```yaml
-!PARSE.ONEOF
-what: "!?."
-```
+	_Input string:_ `Wow!`
+
+	```yaml
+	!PARSE.ONEOF
+	what: "!?."
+	```
 
 
 ---
@@ -262,13 +268,14 @@ or shorter version:
 !PARSE.NONEOF <...>
 ```
 
-## Example
-_Input string:_ `Wow`==!==
+!!! example
 
-```yaml
-!PARSE.NONEOF
-what: ",;:[]()"
-```
+	_Input string:_ `Wow!`
+
+	```yaml
+	!PARSE.NONEOF
+	what: ",;:[]()"
+	```
 
 
 ---
@@ -291,23 +298,24 @@ or shorter version:
 ```
 
 - `stop` - indicates whether the stop character should be parsed or not.
-            Possible values: `before` or `after`(default).
+			Possible values: `before` or `after`(default).
 
 - `eof` - indicates if we should parse till the end of the string if `what` symbol is not found.
-            Possible values: `true` or `false`(default).
+			Possible values: `true` or `false`(default).
 
 
 !!! info
 
-        Field `what` must be a single character. But some whitespace characters can also be used  ex: `tab`
+		Field `what` must be a single character. But some whitespace characters can also be used such as `tab`.
 
-## Example
-_Input string:_ `60290:11`
+!!! example
 
-```yaml
-!PARSE.UNTIL
-what: ":"
-```
+	_Input string:_ `60290:11`
+
+	```yaml
+	!PARSE.UNTIL
+	what: ":"
+	```
 
 <details>
   <summary>More examples</summary>
@@ -356,13 +364,14 @@ or shorter version:
 !PARSE.EXACTLY <...>
 ```
 
-## Example
-_Input string:_ `Hello world!`
+!!! example
 
-```yaml
-!PARSE.EXACTLY
-what: "Hello"
-```
+	_Input string:_ `Hello world!`
+
+	```yaml
+	!PARSE.EXACTLY
+	what: "Hello"
+	```
 
 
 ---
@@ -392,14 +401,15 @@ or shorter version:
 - `escape` - indicates escape character.
 
 
-## Example
-_Input string:_ `[10/May/2023:08:15:54 +0000]`
+!!! example
 
-```yaml
-!PARSE.BETWEEN
-start: '['
-stop: ']'
-```
+	_Input string:_ `[10/May/2023:08:15:54 +0000]`
+
+	```yaml
+	!PARSE.BETWEEN
+	start: '['
+	stop: ']'
+	```
 
 <details>
   <summary>More examples</summary>
@@ -440,15 +450,16 @@ Type: _Parser_.
 what: <...>
 ```
 
-## Example
-_Input string:_ `FTVW23_L-C: Message..`
+!!! example
 
-_Output:_ `FTVW23_L-C`
+	_Input string:_ `FTVW23_L-C: Message...`
 
-```yaml
-!PARSE.REGEX
-what: '[a-zA-Z0-9_\-0]+'
-```
+	_Output:_ `FTVW23_L-C`
+
+	```yaml
+	!PARSE.REGEX
+	what: '[a-zA-Z0-9_\-0]+'
+	```
 
 
 ---
@@ -468,32 +479,34 @@ or shorter version:
 !PARSE.MONTH <...>
 ```
 
-- `what` - indicates a format of the month name.
-            Possible values: `number`, `short`, `full`.
+- `what` - indicates a format of the month name. Possible values: `number`, `short`, `full`.
 
 !!! tip
-    Use `!PARSE.MONTH` to parse month name as part of `!PARSE.DATETIME`.
+	Use `!PARSE.MONTH` to parse month name as part of `!PARSE.DATETIME`.
 
 
-## Example
-_Input string:_ `10/`==May==`/2023:08:15:54`
+!!! example
 
-```yaml
-!PARSE.MONTH
-what: 'short'
-```
+	_Input string:_ `10/`==May==`/2023:08:15:54`
+
+	```yaml
+	!PARSE.MONTH
+	what: 'short'
+	```
 
 <details>
   <summary>More examples</summary>
 
 Parse month in number format:<br>
 <i>Input string:</i><code>2003-<mark>10</mark>-11</code>
+
 ```yaml
 !PARSE.MONTH 'number'
 ```
 
 Parse month in full format:<br>
 <i>Input string:</i><code>2003-<mark>OCTOBER</mark>-11</code>
+
 ```yaml
 !PARSE.MONTH
 what: 'full'
@@ -516,22 +529,23 @@ max: <...>
 ```
 
 - `base` - indicates a base of the fraction.
-            Possible values: `milli`, `micro`, `nano`.
+			Possible values: `milli`, `micro`, `nano`.
 - `max` - indicates a maximum number of digits depending on the `base` value.
-            Possible values: `3`, `6`, `9` respectively.
+			Possible values: `3`, `6`, `9` respectively.
 
 !!! tip
-    Use `!PARSE.FRAC` to parse microseconds or nanoseconds as part of `!PARSE.DATETIME`.
+	Use `!PARSE.FRAC` to parse microseconds or nanoseconds as part of `!PARSE.DATETIME`.
 
 
-## Example
-_Input string:_ `Aug 22 05:40:14`==.264==
+!!! example
 
-```yaml
-!PARSE.FRAC
-base: "micro"
-max: 6
-```
+	_Input string:_ `Aug 22 05:40:14`==.264==
+
+	```yaml
+	!PARSE.FRAC
+	base: "micro"
+	max: 6
+	```
 
 
 ---
@@ -559,8 +573,7 @@ Type: _Parser_.
 - Field `year` is optional. If not specified, the _smart year_ function will be used.
 - Fields `hour`, `minute`, `second`,  `microsecond`, `nanosecond` are optional. If not specified, the default value 0 will be used.
 - Specifying microseconds field like `microseconds?`, allow to parse microseconds or not  depends on their present in the input string.
-- Field `timezone` is optional. If not specified, the default value `UTC` will be used.
-  - `timezone` can be specified in two different formats.
+- Field `timezone` is optional. If not specified, the default value `UTC` will be used. It can be specified in two different formats.
     1. `Z`, `+08:00` - parsed from the input string.
     2. `Europe/Prague` - specified as a constant value.
 
@@ -576,27 +589,27 @@ Shortcut forms are available (in both lower/upper variants):
 !PARSE.DATETIME iso8601
 ```
 
-## Example
-_Input string:_ `2022-10-13T12:34:56.987654`
+!!! example
+	_Input string:_ `2022-10-13T12:34:56.987654`
 
-```yaml
-!PARSE.DATETIME
-- year: !PARSE.DIGITS
-- '-'
-- month: !PARSE.MONTH 'number'
-- '-'
-- day: !PARSE.DIGITS
-- 'T'
-- hour: !PARSE.DIGITS
-- ':'
-- minute: !PARSE.DIGITS
-- ':'
-- second: !PARSE.DIGITS
-- microsecond: !PARSE.FRAC
-                base: "micro"
-                max: 6
-- timezone: "Europe/Prague"
-```
+	```yaml
+	!PARSE.DATETIME
+	- year: !PARSE.DIGITS
+	- '-'
+	- month: !PARSE.MONTH 'number'
+	- '-'
+	- day: !PARSE.DIGITS
+	- 'T'
+	- hour: !PARSE.DIGITS
+	- ':'
+	- minute: !PARSE.DIGITS
+	- ':'
+	- second: !PARSE.DIGITS
+	- microsecond: !PARSE.FRAC
+					base: "micro"
+					max: 6
+	- timezone: "Europe/Prague"
+	```
 
 <details>
   <summary>More examples</summary>
@@ -615,8 +628,8 @@ Parse datetime without year, with short month form and optional microseconds:<br
 - !PARSE.EXACTLY { what: ':' }
 - second: !PARSE.DIGITS # Seconds
 - microsecond?: !PARSE.FRAC # Microseconds
-                base: "micro"
-                max: 6
+				base: "micro"
+				max: 6
 ```
 
 Parse datetime with timezone:<br>
@@ -803,7 +816,7 @@ Type: _Combinator_.
 ```
 
 !!!tip
-    Use `!PARSE.TRIE` to parse multivariance log messages.
+	Use `!PARSE.TRIE` to parse multivariance log messages.
   
 ## Example
 _Input string:_ `Received disconnect from 10.17.248.1 port 60290:11: disconnected by user`
@@ -811,16 +824,16 @@ _Input string:_ `Received disconnect from 10.17.248.1 port 60290:11: disconnecte
 ```yaml
 !PARSE.TRIE
 - 'Received disconnect from ': !PARSE.KVLIST
-    - CLIENT_IP: !PARSE.UNTIL ' '
-    - 'port '
-    - CLIENT_PORT: !PARSE.DIGITS
-    - ':'
-    - !PARSE.CHARS
+	- CLIENT_IP: !PARSE.UNTIL ' '
+	- 'port '
+	- CLIENT_PORT: !PARSE.DIGITS
+	- ':'
+	- !PARSE.CHARS
 - 'Disconnected from user ': !PARSE.KVLIST
-    - USERNAME: !PARSE.UNTIL ' '
-    - CLIENT_IP: !PARSE.UNTIL ' '
-    - 'port '
-    - CLIENT_PORT: !PARSE.DIGITS
+	- USERNAME: !PARSE.UNTIL ' '
+	- CLIENT_IP: !PARSE.UNTIL ' '
+	- 'port '
+	- CLIENT_PORT: !PARSE.DIGITS
 ```
 
 
@@ -858,7 +871,7 @@ _Input strings:_
 - !PARSE.EXACTLY {what: ']'}
 - !PARSE.OPTIONAL ':'
 - !PARSE.OPTIONAL
-    what: !PARSE.SPACE
+	what: !PARSE.SPACE
 - NAME: !PARSE.UNTIL {what: ' '}
 ```
 
@@ -881,7 +894,7 @@ Type: _Combinator_
 ```
 
 !!!tip
-    Use  combination of  `!PARSE.REPEAT` and `!PARSE.KV` to parse repeated key-value pairs. (see examples)
+	Use  combination of  `!PARSE.REPEAT` and `!PARSE.KV` to parse repeated key-value pairs. (see examples)
  
 ## Example
 _Input string:_ `eventID= "1011"`
@@ -914,12 +927,12 @@ _Output:_ `(eventID, 1011)`
 ```yaml
 !PARSE.REPEAT
 what: !PARSE.KV
-    - !PARSE.OPTIONAL
-      what: !PARSE.SPACE
-    - key: !PARSE.UNTIL '='
-    - value: !TRY
-            - !PARSE.BETWEEN '"'
-            - !PARSE.UNTIL { what: ' ', eof: true}
+	- !PARSE.OPTIONAL
+	  what: !PARSE.SPACE
+	- key: !PARSE.UNTIL '='
+	- value: !TRY
+			- !PARSE.BETWEEN '"'
+			- !PARSE.UNTIL { what: ' ', eof: true}
 ```
 <i>Output:</i> <code>[(devid, FEVM020000191439), (vd, root), (itime, 1665629867)]</code>
 </details>
@@ -959,16 +972,16 @@ _Input string:_ `<141>May  9 10:00:00 VUW-DC-F5-P2R1.source-net.com notice tmm1[
   - log.syslog.priority: !PARSE.DIGITS
   - '>'
   - '@timestamp': !PARSE.DATETIME
-                - month: !PARSE.MONTH 'short'
-                - !PARSE.SPACES
-                - day: !PARSE.DIGITS # Day
-                - !PARSE.SPACES
-                - hour: !PARSE.DIGITS # Hours
-                - ':'
-                - minute: !PARSE.DIGITS # Minutes
-                - ':'
-                - second: !PARSE.DIGITS # Seconds
-                - timezone: "Europe/Prague"
+				- month: !PARSE.MONTH 'short'
+				- !PARSE.SPACES
+				- day: !PARSE.DIGITS # Day
+				- !PARSE.SPACES
+				- hour: !PARSE.DIGITS # Hours
+				- ':'
+				- minute: !PARSE.DIGITS # Minutes
+				- ':'
+				- second: !PARSE.DIGITS # Seconds
+				- timezone: "Europe/Prague"
   - !PARSE.SPACES
   - host.hostname: !PARSE.UNTIL ' '
   - log.level: !PARSE.UNTIL ' '

--- a/docs/expressions/parsec.md
+++ b/docs/expressions/parsec.md
@@ -25,7 +25,7 @@ Every expression starts with `!PARSE.` prefix.
 
 Type: _Parser_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.DIGIT
@@ -46,7 +46,7 @@ Type: _Parser_.
 
 Type: _Parser_.
 
-### Synopsis
+Synopsis:
 
 
 ```yaml
@@ -101,7 +101,7 @@ Latin letters from A to Z, both uppercase and lowercase.
 
 Type: _Parser_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.LETTER
@@ -123,7 +123,7 @@ Any type of character.
 
 Type: _Parser_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.CHAR
@@ -144,7 +144,7 @@ Type: _Parser_.
 
 Type: _Parser_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.CHARS
@@ -202,7 +202,7 @@ max: 4
 
 Type: _Parser_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.SPACE
@@ -217,7 +217,7 @@ Parse as many space symbols as possible:
 
 Type: _Parser_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.SPACES
@@ -230,7 +230,7 @@ Type: _Parser_.
 
 Type: _Parser_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.ONEOF
@@ -257,7 +257,7 @@ or shorter version:
 
 Type: _Parser_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.NONEOF
@@ -284,7 +284,7 @@ or shorter version:
 
 Type: _Parser_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.UNTIL
@@ -353,7 +353,7 @@ what: 'tab'
 
 Type: _Parser_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.EXACTLY
@@ -380,7 +380,7 @@ or shorter version:
 
 Type: _Parser_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.BETWEEN
@@ -443,7 +443,7 @@ escape: '\'
 
 Type: _Parser_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.REGEX
@@ -468,7 +468,7 @@ what: <...>
 
 Type: _Parser_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.MONTH
@@ -520,7 +520,7 @@ what: 'full'
 
 Type: _Parser_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.FRAC
@@ -555,7 +555,7 @@ max: <...>
 Type: _Parser_.
 
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.DATETIME
@@ -690,7 +690,7 @@ Parse datetime with nanoseconds:<br>
 
 Type: _Combinator_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.REPEAT
@@ -740,7 +740,7 @@ max: 4
 
 Type: _Combinator_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.SEPARATED
@@ -806,7 +806,7 @@ Type: _Combinator_.
 
 `!PARSE.TRIE` expression chooses one of the specified prefixes and parse the rest of the input string using the corresponding parser.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.TRIE
@@ -846,7 +846,7 @@ Type: _Combinator_
 `!PARSE.OPTIONAL` expression tries to parse the input string using the specified parser. If the parser fails, starting position rolls back to the initial one.
 
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.OPTIONAL
@@ -883,7 +883,7 @@ _Input strings:_
 Type: _Combinator_
 
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.KV
@@ -948,7 +948,7 @@ Nested `!PARSE.KVLIST` expressions are joined to the parent one.
 Type: _Combinator_
 
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.KVLIST
@@ -1003,7 +1003,7 @@ Iterating through list of elements `!PARSE.TUPLE` expression collects values to 
 Type: _Combinator_
 
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.TUPLE
@@ -1037,7 +1037,7 @@ Iterating through list of elements `!PARSE.RECORD` expression collects values to
 Type: _Combinator_
 
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !PARSE.RECORD

--- a/docs/expressions/record.md
+++ b/docs/expressions/record.md
@@ -4,15 +4,13 @@ title: Record
 
 # Record expressions
 
-
-
 The record is one of basic data structures provided by SP-Lang.
 A record is a collection of items, possibly of different types.
 Items of a record are named (in a contrast to a tuple) by a label.
 
 !!! note
 
-    The record is built on top of `!TUPLE`.
+	The record is built on top of `!TUPLE`.
 
 --- 
 
@@ -20,7 +18,7 @@ Items of a record are named (in a contrast to a tuple) by a label.
 
 Type:  _Mapping_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !RECORD
@@ -35,42 +33,39 @@ with:
 There is no limit of the number of items in the record.
 The order of the items is preserved.
 
-### Examples
+!!! example
 
-```yaml
-!RECORD
-with:
-  name: John Doe
-  age: 37
-  height: 175.4
-```
+	```yaml
+	!RECORD
+	with:
+	  name: John Doe
+	  age: 37
+	  height: 175.4
+	```
 
+!!! example "Use of the YAML flow form:"
 
-Use of the YAML flow form:
+	```yaml
+	!RECORD {with: {name: John Doe, age: 37, height: 175.4} }
+	```
 
-```yaml
-!RECORD {with: {name: John Doe, age: 37, height: 175.4} }
-```
+!!! example "Use of the `!!record` tag:"
 
+	```yaml
+	!!record {name: John Doe, age: 37, height: 175.4}
+	```
 
-Use of the `!!record` tag:
+!!! example "Enforce specific type of the item:"
 
-```yaml
-!!record {name: John Doe, age: 37, height: 175.4}
-```
+	```yaml
+	!RECORD
+	with:
+	  name: John Doe
+	  age: !!ui8 37
+	  height: 175.4
+	```
 
-
-Enforce specific type of the item:
-
-```yaml
-!RECORD
-with:
-  name: John Doe
-  age: !!ui8 37
-  height: 175.4
-```
-
-Field `age` will have a type `ui8`.
+	Field `age` will have a type `ui8`.
 
 
 --- 
@@ -79,7 +74,7 @@ Field `age` will have a type `ui8`.
 
 Type: _Mapping_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !GET
@@ -95,51 +90,49 @@ Items are indexed from the 0, it means that the first item in the list has an in
 If the `what` is out of bound of the list, the statement returns with error.
 
 
-### Examples
+!!! example "Using names of items:"
 
-Using names of items:
+	```yaml
+	!GET
+	what: name
+	from:
+	  !RECORD
+	  with:
+	    name: John Doe
+	    age: 32 let
+	    height: 127,5
+	```
 
-```yaml
-!GET
-what: name
-from:
-  !RECORD
-  with:
-    name: John Doe
-    age: 32
-    height: 127.5
-```
-
-Returns `John Doe`.
+	Returns `John Doe`.
 
 
-Using the _index_ of items:
+!!! example "Using the _index_ of items:"
 
-```yaml
-!GET
-what: 1
-from:
-  !RECORD
-  with:
-    name: John Doe
-    age: 32
-    height: 127.5
-```
+	```yaml
+	!GET
+	what: 1
+	from:
+	  !RECORD
+	-  with:
+	    name: John Doe
+	    age: 32
+	    height: 127.5
+	```
 
-Returns `32`, a value of `age` item.
+	Returns `32`, a value of `age` item.
 
 
-Using the _negative index_ of items:
+!!! example "Using the _negative index_ of items:"
 
-```yaml
-!GET
-what: -1
-from:
-  !RECORD
-  with:
-    name: John Doe
-    age: 32
-    height: 127.5
-```
+	```yaml
+	!GET
+	what: -1
+	from:
+	  !RECORD
+	  with:
+		name: John Doe
+		age: 32
+		height: 127.5
+	```
 
-Returns `127.5`, a value of `height` item.
+	Returns `127.5`, a value of `height` item.

--- a/docs/expressions/regex.md
+++ b/docs/expressions/regex.md
@@ -15,7 +15,7 @@ title: Regex
 
 Type: _Mapping_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !REGEX
@@ -63,7 +63,7 @@ miss: "No ;-("
 
 Type: _Mapping_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !REGEX.REPLACE
@@ -92,7 +92,7 @@ Returns: `Hello Mars!`
 
 Type: _Mapping_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !REGEX.SPLIT
@@ -122,7 +122,7 @@ Returns: `['07', '14', '2007', '12', '34', '56']`
 
 Type: _Mapping_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !REGEX.FINDALL

--- a/docs/expressions/regex.md
+++ b/docs/expressions/regex.md
@@ -33,33 +33,33 @@ The expression `hit` is optional, default value is `true`.
 The expression `miss` is optional, default value is `false`.
 
 
-### Example
+!!! example
 
-```yaml
-!IF
-test:
-  !REGEX
-  what: "Hello world!"
-  regex: "world"
-then:
-  "Yes :-)"
-else:
-  "No ;-("
+    ```yaml
+    !IF
+    test:
+      !REGEX
+      what: "Hello world!"
+      regex: "world"
+    then:
+      "Yes :-)"
+    else:
+      "No ;-("
 ```
 
-The above example can be also written as:
-  
-```yaml
-!REGEX
-what: "Hello world!"
-regex: "world"
-hit: "Yes :-)"
-miss: "No ;-("
-```
+!!! example "Another form:"
+
+    ```yaml
+    !REGEX
+    what: "Hello world!"
+    regex: "world"
+    hit: "Yes :-)"
+    miss: "No ;-("
+    ```
 
 --- 
 
-## `!REGEX.REPLACE`: Regular expression replace  
+## `!REGEX.REPLACE`: Regular expression replace
 
 Type: _Mapping_.
 
@@ -75,16 +75,16 @@ by: <string>
 Replace regular expression `regex` matches in `what` by value of `by`.
 
 
-### Example
+!!! example
 
-```yaml
-!REGEX.REPLACE
-what: "Hello world!"
-regex: "world"
-by: "Mars"
-```
+    ```yaml
+    !REGEX.REPLACE
+    what: "Hello world!"
+    regex: "world"
+    by: "Mars"
+    ```
 
-Returns: `Hello Mars!`
+    Returns: `Hello Mars!`
 
 --- 
 
@@ -108,13 +108,13 @@ An optional argument `max` specify the maximum number of splits.
 
 ### Example
 
-```yaml
-!REGEX.SPLIT
-what: "07/14/2007 12:34:56"
-regex: "[/ :]"
-```
+    ```yaml
+    !REGEX.SPLIT
+    what: "07/14/2007 12:34:56"
+    regex: "[/ :]"
+    ```
 
-Returns: `['07', '14', '2007', '12', '34', '56']`
+    Returns: `['07', '14', '2007', '12', '34', '56']`
 
 --- 
 
@@ -132,15 +132,15 @@ regex: <regex>
 
 Find all matches of `regex` in the string `what`.
 
-### Example
+!!! example
 
-```yaml
-!REGEX.FINDALL
-what: "Frodo, Sam, Gandalf, Legolas, Gimli, Aragorn, Boromir, Merry, Pippin"
-regex: \w+
-```
+    ```yaml
+    !REGEX.FINDALL
+    what: "Frodo, Sam, Gandalf, Legolas, Gimli, Aragorn, Boromir, Merry, Pippin"
+    regex: \w+
+    ```
 
-Returns: `['Frodo', 'Sam', 'Gandalf', 'Legolas', 'Gimli', 'Aragorn', 'Boromir', 'Merry', 'Pippin']`
+    Returns: `['Frodo', 'Sam', 'Gandalf', 'Legolas', 'Gimli', 'Aragorn', 'Boromir', 'Merry', 'Pippin']`
 
 ---
 
@@ -148,3 +148,4 @@ Returns: `['Frodo', 'Sam', 'Gandalf', 'Legolas', 'Gimli', 'Aragorn', 'Boromir', 
 
 Type: _Mapping_.
 
+See the chapter [`!PARSE.REGEX`](../parsec/#parseregex-parse-a-sequence-of-characters-that-matches-a-regular-expression)

--- a/docs/expressions/set.md
+++ b/docs/expressions/set.md
@@ -25,51 +25,54 @@ Synopsis:
 - ...
 ```
 
-_Hint: Use `!COUNT` to determine number of items in the set._
+!!! hint
 
-
-### Examples
+    Use `!COUNT` to determine number of items in the set.
 
 There are several ways, how a set can be specified in SP-Lang:
 
-```yaml
-!SET
-- "One"
-- "Two"
-- "Three"
-- "Four"
-- "Five"
-```
+!!! example
 
+    ```yaml
+    !SET
+    - "One"
+    - "Two"
+    - "Three"
+    - "Four"
+    - "Five"
+    ```
 
-[YAML unordered set](https://yaml.org/spec/1.2.2/#example-unordered-sets):
+!!! example
 
-```yaml
-!!set
-? Yellow pork
-? Pink grass
-? White snow
-```
+    [YAML unordered set](https://yaml.org/spec/1.2.2/#example-unordered-sets):
 
+    ```yaml
+    !!set
+    ? Yellow pork
+    ? Pink grass
+    ? White snow
+    ```
 
-Consise set using [YAML flow sequences](https://yaml.org/spec/1.2.2/#741-flow-sequences):
+!!! example
 
-```yaml
-!SET ["One", "Two", "Three", "Four", "Five"]
-```
+    Concise set using [YAML flow sequences](https://yaml.org/spec/1.2.2/#741-flow-sequences):
 
+    ```yaml
+    !SET ["One", "Two", "Three", "Four", "Five"]
+    ```
 
-The mapping form:
+!!! example
+    The mapping form:
 
-```yaml
-!SET
-with:
-  - "One"
-  - "Two"
-  - "Three"
-  - "Four"
-  - "Five"
-```
+    ```yaml
+    !SET
+    with:
+    - "One"
+    - "Two"
+    - "Three"
+    - "Four"
+    - "Five"
+    ```
 
 
 --- 
@@ -88,18 +91,18 @@ where: <set>
 
 Check if `item` is present in the `set`.
 
-The expression `!IN` is described in the "Tests" chapter.
+The expression `!IN` is described in the [Comparisons](../comparisons/#in-membership-test) chapter.
 
-### Example
+!!! example
 
-```yaml
-!IN
-what: 3
-where:
-  !SET
-  with:
-    - 1
-    - 2
-    - 5
-    - 8 
-```
+    ```yaml
+    !IN
+    what: 3
+    where:
+      !SET
+      with:
+        - 1
+        - 2
+        - 5
+        - 8 
+    ```

--- a/docs/expressions/set.md
+++ b/docs/expressions/set.md
@@ -17,7 +17,7 @@ A set is best suited for a testing value for membership rather than retrieving a
 
 Type:  _Implicit sequence_, _Mapping_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !SET
@@ -78,7 +78,7 @@ with:
 
 Type: _Mapping_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !IN

--- a/docs/expressions/string.md
+++ b/docs/expressions/string.md
@@ -24,15 +24,15 @@ where: <...>
 Evaluate to `true` if it finds a substring `what` in the string `where` and false otherwise.
 
 
-### Example
+!!! example
 
-```yaml
-!IN
-what: "Willy"
-where: "John Willy Boo"
-```
+    ```yaml
+    !IN
+    what: "Willy"
+    where: "John Willy Boo"
+    ```
 
-Check for a presence of the substring "Willy" in the `where` value. Returns `true`.
+    Check for a presence of the substring "Willy" in the `where` value. Returns `true`.
 
 
 ### Multi-string variant
@@ -52,24 +52,24 @@ This is very efficient way of checking if at least one substring is present in t
 It provides [Incremental String Matching](http://se.ethz.ch/~meyer/publications/string/string_matching.pdf) algorithm for fast pattern matching in strings.
 It makes it an ideal tool for complex filtering as a standalone bit or an optimization technique.
 
-Example of `!REGEX` optimization by multi-string `!IN`:
+!!! example "Example of `!REGEX` optimization by multi-string `!IN`:"
 
-```yaml
-!AND
-- !IN
-  where: !ARG message
-  what:
-  - "msgbox"
-  - "showmod"
-  - "showhelp"
-  - "prompt"
-  - "write"
-  - "test"
-  - "mail.com"
-- !REGEX
-  what: !ARG message
-  regex: '(msgbox|showmod(?:al|eless)dialog|showhelp|prompt|write)|(test[0-9])|([a-z]@mail\.com)'
-```
+    ```yaml
+        !AND
+        - !IN
+          where: !ARG message
+          what:
+          - "msgbox"
+          - "showmod"
+          - "showhelp"
+          - "prompt"
+          - "write"
+          - "test"
+          - "mail.com"
+        - !REGEX
+          what: !ARG message
+          regex: "(msgbox|showmod(?:al|eless)dialog|showhelp|prompt|write)|(test[0-9])|([a-z]@mail\.com)
+    ```
 
 This approach is recommended from applications in streams, where you need to filter an extensive amount of the data with assumption that only a smaller portion of the data matches the patters.
 An application of the `!REGEX` expression directly will slow processing down significantly, because it is complex regular expression.
@@ -100,13 +100,13 @@ prefix: <...>
 ```
 
 
-### Example
+!!! example
 
-```yaml
-!STARTSWITH
-what: "FooBar"
-prefix: "Foo"
-```
+    ```yaml
+    !STARTSWITH
+    what: "FooBar"
+    prefix: "Foo"
+    ```
 
 ### Multi-string variant
 
@@ -133,7 +133,6 @@ Returns `true` if `what` string ends with `postfix`.
 
 Type: _Mapping_
 
-
 Synopsis:
 
 ```yaml
@@ -143,13 +142,13 @@ postfix: <...>
 ```
 
 
-### Example
+!!! example
 
-```yaml
-!ENDSWITH
-what: "autoexec.bat"
-postfix: ".bat"
-```
+    ```yaml
+    !ENDSWITH
+    what: "autoexec.bat"
+    postfix: ".bat"
+    ```
 
 ### Multi-string variant
 
@@ -191,16 +190,16 @@ to: <...>
     The first character of the string is located on position `from=0`.
 
 
-### Example
+!!! example
 
-```yaml
-!SUBSTRING
-what: "FooBar"
-from: 1
-to: 3
-```
+    ```yaml
+    !SUBSTRING
+    what: "FooBar"
+    from: 1
+    to: 3
+    ```
 
-Returns `oo`.
+    Returns `oo`.
 
 ---
 
@@ -217,14 +216,14 @@ what: <...>
 ```
 
 
-### Example
+!!! example
 
-```yaml
-!LOWER
-what: "FooBar"
-```
+    ```yaml
+    !LOWER
+    what: "FooBar"
+    ```
 
-Returns `foobar`.
+    Returns `foobar`.
 
 
 ---
@@ -241,14 +240,14 @@ what: <...>
 ```
 
 
-### Example
+!!! example
 
-```yaml
-!UPPER
-what: "FooBar"
-```
+    ```yaml
+    !UPPER
+    what: "FooBar"
+    ```
 
-Returns `FOOBAR`.
+    Returns `FOOBAR`.
 
 ---
 
@@ -272,26 +271,27 @@ The argument `field` specifies a number of the splited strings to return, starti
 If the negative `field` is provided, then field is taken from the end of the string, for example -2 means the second last substring.
 
 
-### Example
+!!! example
 
-```yaml
-!CUT
-what: "Apple,Orange,Melon,Citrus,Pear"
-delimiter: ","
-field: 2
-```
+    ```yaml
+    !CUT
+    what: "Apple,Orange,Melon,Citrus,Pear"
+    delimiter: ","
+    field: 2
+    ```
 
-Will return value "Melon".
+    Will return value "Melon".
 
+!!! example
 
-```yaml
-!CUT
-what: "Apple,Orange,Melon,Citrus,Pear"
-delimiter: ","
-field: -2
-```
+    ```yaml
+    !CUT
+    what: "Apple,Orange,Melon,Citrus,Pear"
+    delimiter: ","
+    field: -2
+    ```
 
-Will return value "Citrus".
+    Will return value "Citrus".
 
   
 ---
@@ -315,15 +315,15 @@ The argument `what` string will be split using a `delimiter` argument.
 An optional `maxsplit` arguments specifies how many splits to do.
 
 
-### Example
+!!! example
 
-```yaml
-!SPLIT
-what: "hello,world"
-delimiter: ","
-```
+    ```yaml
+    !SPLIT
+    what: "hello,world"
+    delimiter: ","
+    ```
 
-The result is a list: `["hello", "world"]`.
+    The result is a list: `["hello", "world"]`.
 
 ---
 
@@ -368,12 +368,12 @@ Default `delimiter` is space (" ").
 If the item is `None`, then the value of `miss` parameter is used, by default it is empty string.
 If `miss` is `None` and  any of `items` is `None`, the result of the whole join is `None`.
 
-### Example
+!!! example
 
-```yaml
-!JOIN
-items:
-  - "Foo"
-  - "Bar"
-delimiter: ','
-```
+    ```yaml
+    !JOIN
+    items:
+      - "Foo"
+      - "Bar"
+    delimiter: ','
+    ```

--- a/docs/expressions/string.md
+++ b/docs/expressions/string.md
@@ -13,7 +13,7 @@ The `!IN` expression is used to check if a string `what` exists in a string `whe
 
 Type: _Mapping_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !IN
@@ -91,7 +91,7 @@ Returns `true` if `what` string begins with `prefix`.
 
 Type: _Mapping_
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !STARTSWITH
@@ -134,7 +134,7 @@ Returns `true` if `what` string ends with `postfix`.
 Type: _Mapping_
 
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !ENDSWITH
@@ -177,7 +177,7 @@ Return part of the string `what`, in between `from` and `to` index.
 Type: _Mapping_
 
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !SUBSTRING
@@ -209,7 +209,7 @@ Returns `oo`.
 Type: _Mapping_
 
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !LOWER
@@ -233,7 +233,7 @@ Returns `foobar`.
 
 Type: _Mapping_
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !UPPER
@@ -258,7 +258,7 @@ Cut the string by a delimiter and return the piece identified by `field` index (
 
 Type: _Mapping_
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !CUT
@@ -302,7 +302,7 @@ Splits a string into a list of strings.
 
 Type: _Mapping_
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !SPLIT
@@ -333,7 +333,7 @@ Splits a string from the right (end of the string) into a list of strings.
 
 Type: _Mapping_
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !RSPLIT
@@ -352,7 +352,7 @@ An optional `maxsplit` arguments specifies how many splits to do.
 
 Type: _Mapping_
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !JOIN

--- a/docs/expressions/tuple.md
+++ b/docs/expressions/tuple.md
@@ -28,45 +28,48 @@ There is no limit of the number of items in the tuple.
 The order of the items is preserved.
 
 
-### Examples
+!!! example
 
-```yaml
-!TUPLE
-with:
-  - John Doe
-  - 37
-  - 175.4
-```
+    ```yaml
+    !TUPLE
+    with:
+      - John Doe
+      - 37
+      - 175.4
+    ```
 
+!!! example
 
-Use of the `!!tuple` notation:
+    Use of the `!!tuple` notation:
 
-```yaml
-!!tuple
-- 1
-- a
-- 1.2
-```
+    ```yaml
+    !!tuple
+    - 1
+    - a
+    - 1.2
+    ```
 
+!!! example
 
-Even more concise version of the `!!tuple` using flow syntax:
+    Even more concise version of the `!!tuple` using flow syntax:
 
-```yaml
-!!tuple ['John Doe', 37, 175.4]
-```
+    ```yaml
+    !!tuple ['John Doe', 37, 175.4]
+    ```
 
+!!! example
 
-Enforce specific type of the item:
+    Enforce specific type of the item:
 
-```yaml
-!TUPLE
-with:
-  - John Doe
-  - !!ui8 37
-  - 175.4
-```
+    ```yaml
+    !TUPLE
+    with:
+      - John Doe
+      - !!ui8 37
+      - 175.4
+    ```
 
-Item #1 will have a type `ui8`.
+    Item #1 will have a type `ui8`.
 
 
 --- 
@@ -89,7 +92,7 @@ Items are indexed from the 0, it means that the first item in the list has an in
 If the `what` is out of bound of the list, the statement returns with error.
 
 
-### Examples
+!!! example
 
 ```yaml
 !GET
@@ -102,20 +105,22 @@ from:
     - 127.5
 ```
 
-Returns `32`.
+    Returns `32`.
 
 
-Using the _negative index_ of items:
+!!! example
 
-```yaml
-!GET
-what: -1
-from:
-  !TUPLE
-  with:
-    - John Doe
-    - 32
-    - 127.5
-```
+    Using the _negative index_ of items:
 
-Returns `127.5`.
+    ```yaml
+    !GET
+    what: -1
+    from:
+      !TUPLE
+      with:
+        - John Doe
+        - 32
+        - 127.5
+    ```
+
+    Returns `127,5`.

--- a/docs/expressions/tuple.md
+++ b/docs/expressions/tuple.md
@@ -14,7 +14,7 @@ A tuple is a collection of items, possibly of different types.
 
 Type:  _Mapping_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !TUPLE
@@ -75,7 +75,7 @@ Item #1 will have a type `ui8`.
 
 Type: _Mapping_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !GET

--- a/docs/expressions/utility.md
+++ b/docs/expressions/utility.md
@@ -25,19 +25,19 @@ SP-Lang automatically converts types of arguments so that the user doesn't need 
 This feature is called *implicit casting*.
 
 In case of explicit need for a type conversion, use `!CAST` expression.
-It is very powerful method that do a lot of heavylifting.
+It is very powerful method that do a lot of heavy-lifting.
 
 For more details, see chapter about [types](../../language/types).
 
-### Example
+!!! example
 
-```yaml
-!CAST
-what: "10.3"
-type: fp64
-```
+	```yaml
+	!CAST
+	what: "10.3"
+	type: fp64
+	```
 
-This is an explicit casting of the string into a floating-point number.
+	This is an explicit casting of the string into a floating-point number.
 
 ---
 
@@ -61,7 +61,7 @@ Calculate the hash for an `what` value.
 `type` specifies a hashing function, the default value is `XXH64`.
 
 
-#### Supported hashing functions
+### Supported hashing functions
 
 * `XXH64`: xxHash, 64bit, non-cryptografic, extremely fast hash algorithm
 * `XXH3`: xxHash, 64bit, non-cryptografic, futher optimized for small inputs
@@ -69,13 +69,13 @@ Calculate the hash for an `what` value.
 More information about xxHash are at [xxhash.com](http://www.xxhash.com/)
 
 
-### Example
+!!! example "Příklad"
 
-```yaml
-!HASH
-what: "Hello world!"
-seed: 5
-```
+	```yaml
+	!HASH
+	what: "Hello world!"
+	seed: 5
+	```
 
 
 ---

--- a/docs/expressions/utility.md
+++ b/docs/expressions/utility.md
@@ -11,7 +11,7 @@ title: Utility
 
 Type: _Mapping_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !CAST
@@ -45,7 +45,7 @@ This is an explicit casting of the string into a floating-point number.
 
 Type: _Mapping_.
 
-### Synopsis
+Synopsis:
 
 ```yaml
 !HASH

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,8 @@ markdown_extensions:
   - pymdownx.emoji:
       emoji_index: !!python/name:materialx.emoji.twemoji
       emoji_generator: !!python/name:materialx.emoji.to_svg
+  - toc:
+      permalink: True
 
 extra:
   social:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,7 +45,7 @@ markdown_extensions:
       emoji_index: !!python/name:materialx.emoji.twemoji
       emoji_generator: !!python/name:materialx.emoji.to_svg
   - toc:
-      permalink: True
+      permalink: "¤"
 
 extra:
   social:


### PR DESCRIPTION
## Proofreading

Names of expressions chapters are mostly adjectives: Aggregate -> Agregační, Arithmetics -> Aritmetické, etc.

In specification of expressions, types such as  `mapping`, `sequence`, `scalar`, `implicit sequence`, ...  remain untranslated, although their Czech equivalents are mentioned in tutorial.
![image](https://github.com/TeskaLabs/splang-docs/assets/68327081/f36609f5-91b3-45d7-9a2d-385690b59fc8)
![image](https://github.com/TeskaLabs/splang-docs/assets/68327081/98dbbb06-63c5-4ffa-8aeb-8815cafd760a)

In most of the examples, English is used for argument names.
![image](https://github.com/TeskaLabs/splang-docs/assets/68327081/0de08f20-2fb9-4cc4-916a-57eb1edfa78f)

The term _"Parsing"_ is mostly translated as _"parsování"_ although it is not a part of Czech academical language. Terms like "analyzování" or "procesování" would make confusion to the reader.

![image](https://github.com/TeskaLabs/splang-docs/assets/68327081/c5d1ca9c-5148-4d39-9331-f474ae4b601c)

If the expression description uses  an imperative form, it is translated similar to the following:

![image](https://github.com/TeskaLabs/splang-docs/assets/68327081/d9c5c88a-fdc3-47cd-a97a-5964094eadb2)

![image](https://github.com/TeskaLabs/splang-docs/assets/68327081/e6e4ab44-7e33-44a9-89a8-0b36c36a40b4)

| Term | Translation |
|--- | --- |
| scalar | skalární |
| set | množina |
| dict | slovník |
| parsing | parsování |
| mapping | mapování |
| synopsis | synopsis |

## Other fixes

- Some examples with '### ' level moved to '!!! example'
- Some typos fixed
- Some admonitions were not correctly indented which cause them not to be displayed at all.